### PR TITLE
Base Files/Architecture of Child Chain

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tendermint/tmlibs/log"
 
 	"github.com/tendermint/go-amino" // Not necessary once switched to RLP
-	rlp "github.com/ethereum/go-ethereum/rlp" // TODO: Change from amino to RLP
+	//rlp "github.com/ethereum/go-ethereum/rlp" // TODO: Change from amino to RLP
 
 )
 
@@ -82,7 +82,7 @@ func (app *ChildChain) txDecoder(txBytes []byte) (sdk.Tx, sdk.Error) {
 	// TODO: implement method with RLP
 	var tx = types.BaseTx{}
 	// BaseTx is struct for Msg wrapped with authentication data
-	err := rlp.DecodeBytes(txBytes, &tx)
+	err := app.cdc.UnmarshalBinary(txBytes, &tx)
 	if err != nil {
 		return nil, sdk.ErrTxDecode("").TraceCause(err, "")
 	}
@@ -101,8 +101,8 @@ func MakeCodec() *amino.Codec {
 	cdc.RegisterConcrete(crypto.Signature{}, "go-crypto/Signature", nil)
 	cdc.RegisterConcrete(sdk.StdSignature{}, "sdk/StdSignature", nil)
 	cdc.RegisterInterface((*crypto.PubKeyInner)(nil), nil)
-	cdc.RegisterConcrete(crypto.PubKeyEd25519{}, "go-crypto/PubKeyEd25519", nil)
-	cdc.RegisterConcrete(crypto.SignatureEd25519{}, "go-crypto/SignatureEd25519", nil)
+	cdc.RegisterConcrete(crypto.PubKeySecp256k1{}, "go-crypto/PubKeySecpk1", nil)
+	cdc.RegisterConcrete(crypto.SignatureSecp256k1{}, "go-crypto/SignatureSecpk1", nil)
 	cdc.RegisterInterface((*crypto.SignatureInner)(nil), nil)
 	return cdc
 }

--- a/app/app.go
+++ b/app/app.go
@@ -29,6 +29,8 @@ type ChildChain struct {
 
 	// keys to access the substores
 	capKeyMainStore *sdk.KVStoreKey //capabilities key to access main store from multistore
+	
+	capKeySigStore *sdk.KVStoreKey //capabilities key to access confirm signature store from multistore
 	//Not sure if this is needed
 	capKeyIBCStore *sdk.KVStoreKey //capabilities key to access IBC Store from multistore
 
@@ -47,6 +49,7 @@ func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 	// define the utxoMapper
 	app.utxoMapper = types.NewUTXOMapper(
 		app.capKeyMainStore, // target store
+		app.capKeySigStore,
 		// MYNOTE: may need to change proto
 		&types.BaseUTXOHolder{}, // UTXOHolder is a struct that holds BaseUTXO's
 							 // BaseUTXO implemented UTXO interface

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,95 @@
+package main //change to app
+
+//modeled after basecoinapp in cosmos/cosmos-sdk/examples
+import (
+	bam "github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	dbm "github.com/tendermint/tmlibs/db"
+	crypto "github.com/tendermint/go-crypto"
+	cmn "github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/log"
+	"../types" //should be adjusted to reference our repo
+	"../utxo"
+	"fmt" //for testing
+)
+
+const (
+	appName = "plasmaChildChain"
+)
+
+// Extended ABCI application
+
+type ChildChain struct {
+	*bam.BaseApp // Pointer to the Base App
+	// TODO: Add RLP here?
+
+	// keys to access the substores
+	capKeyMainStore *sdk.KVStoreKey //capabilities key to access main store from multistore
+	//Not sure if this is needed
+	capKeyIBCStore *sdk.KVStoreKey //capabilities key to access IBC Store from multistore
+
+	// Manage addition and deletion of unspent utxo's 
+	// TODO: Add utxo mapper here
+	uxtoMapper utxoMapper
+}
+
+func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
+	var app = &ChildChain{
+		BaseApp:			bam.NewBaseApp(appName, logger, db),
+		capKeyMainStore:	sdk.NewKVStoreKey("main"),
+		capKeyIBCStore:  sdk.NewKVStoreKey("ibc"),
+	}
+
+	// define the utxoMapper
+	app.utxoMapper = NewUTXOMapper(
+		app.capKeyMainStore, // target store
+		&BaseUTXO{},
+	)
+
+	// TODO: add handlers/router
+	// add utxoKeeper
+	
+
+	// initialize BaseApp
+	// set the BaseApp txDecoder to use txDecoder with RLP
+	app.SetTxDecoder(app.txDecoder)
+	
+	// TODO: set initChainer?
+	// TO-UNDERSTAND: Not sure what mounting does yet
+	app.MountStoresIAVL(app.capKeyMainStore)
+	
+	// TO-UNDERSTAND: What does ante handler do, do i need to make a new one
+	//app.setAnteHandler()
+	
+	// TODO: set ante handler
+	err := app.LoadLatestVersion(app.capKeyMainStore)
+	if err != nil {
+		cmn.Exit(err.Error())
+	}
+
+	return app
+}
+
+// TODO: change sdk.Tx to different transaction struct
+func (app *ChildChain) txDecoder(txBytes []byte) (sdk.Tx, sdk.Error) {
+	// TODO: implement method
+	var tx = sdk.StdTx{}
+	return tx, nil
+}
+
+
+// TODO: Add initChainer?
+
+// TODO: delete this
+func main() {
+	fmt.Println("Compiled :)")
+}
+
+
+
+// Current big idea TODO List:
+// 1. Build Prototype for UTXO
+// 2. Implement txDecoder
+// 3. Implement Handlers
+// 4. Implement AnteHandler
+// 5. Write Basic Test Case and run

--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,5 @@
 package app 
 
-//modeled after basecoinapp in cosmos/cosmos-sdk/examples
 import (
 	// TODO: Change to import from FourthState repo (currently not on there)
 	types "plasma-mvp-sidechain/types" //points to a local package
@@ -9,11 +8,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	dbm "github.com/tendermint/tmlibs/db"
 	cmn "github.com/tendermint/tmlibs/common"
-	crypto "github.com/tendermint/go-crypto"
 	"github.com/tendermint/tmlibs/log"
+	crypto "github.com/tendermint/go-crypto"
 
 	"github.com/tendermint/go-amino" // Not necessary once switched to RLP
 	//rlp "github.com/ethereum/go-ethereum/rlp" // TODO: Change from amino to RLP
+
 
 )
 
@@ -25,7 +25,8 @@ const (
 type ChildChain struct {
 	*bam.BaseApp // Pointer to the Base App
 
-	cdc *amino.Codec // Delete once changed to RLP
+	cdc *amino.Codec
+
 	// keys to access the substores
 	capKeyMainStore *sdk.KVStoreKey //capabilities key to access main store from multistore
 	//Not sure if this is needed
@@ -38,7 +39,7 @@ type ChildChain struct {
 func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 	var app = &ChildChain{
 		BaseApp:			bam.NewBaseApp(appName, logger, db),
-		cdc:				MakeCodec(),
+		cdc: MakeCodec(),
 		capKeyMainStore:	sdk.NewKVStoreKey("main"),
 		capKeyIBCStore:  	sdk.NewKVStoreKey("ibc"),
 	}
@@ -61,14 +62,11 @@ func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 	// set the BaseApp txDecoder to use txDecoder with RLP
 	app.SetTxDecoder(app.txDecoder)
 	
-	// TODO: set initChainer?
 	// TO-UNDERSTAND: Not sure what mounting does yet
 	app.MountStoresIAVL(app.capKeyMainStore)
 	
-	// TO-UNDERSTAND: What does ante handler do, do i need to make a new one
-	//app.setAnteHandler()
-	
-	// TODO: set ante handler
+	// TODO: Make ante handler
+	//
 	err := app.LoadLatestVersion(app.capKeyMainStore)
 	if err != nil {
 		cmn.Exit(err.Error())

--- a/app/app.go
+++ b/app/app.go
@@ -8,9 +8,11 @@ import (
 	crypto "github.com/tendermint/go-crypto"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
-	"../types" //should be adjusted to reference our repo
-	"../utxo"
+	//"../types" //should be adjusted to reference our repo
+	//"../utxo"
 	"fmt" //for testing
+	"github.com/ethereum/go-ethereum/rlp"
+
 )
 
 const (
@@ -37,7 +39,7 @@ func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 	var app = &ChildChain{
 		BaseApp:			bam.NewBaseApp(appName, logger, db),
 		capKeyMainStore:	sdk.NewKVStoreKey("main"),
-		capKeyIBCStore:  sdk.NewKVStoreKey("ibc"),
+		capKeyIBCStore:  	sdk.NewKVStoreKey("ibc"),
 	}
 
 	// define the utxoMapper
@@ -47,8 +49,10 @@ func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 	)
 
 	// TODO: add handlers/router
-	// add utxoKeeper
-	
+	// UTXOKeeper to adjust spending and recieving of utxo's
+	UTXOKeeper := NewUTXOKeeper(app.utxoMapper)
+	app.Router().
+		AddRoute("txs", NewHandler(UTXOKeeper))
 
 	// initialize BaseApp
 	// set the BaseApp txDecoder to use txDecoder with RLP
@@ -73,23 +77,19 @@ func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 // TODO: change sdk.Tx to different transaction struct
 func (app *ChildChain) txDecoder(txBytes []byte) (sdk.Tx, sdk.Error) {
 	// TODO: implement method
-	var tx = sdk.StdTx{}
-	return tx, nil
+	return nil
 }
-
 
 // TODO: Add initChainer?
 
 // TODO: delete this
 func main() {
-	fmt.Println("Compiled :)")
+	fmt.Println("Compiled")
 }
 
 
 
 // Current big idea TODO List:
-// 1. Build Prototype for UTXO
-// 2. Implement txDecoder
-// 3. Implement Handlers
+// - Implement RLP Encoding/Decoding in app.go and tx.go
 // 4. Implement AnteHandler
-// 5. Write Basic Test Case and run
+// 5. Write Basic Test Cases

--- a/app/app.go
+++ b/app/app.go
@@ -1,17 +1,16 @@
-package main //change to app
+package app //change to app
 
 //modeled after basecoinapp in cosmos/cosmos-sdk/examples
 import (
 	bam "github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	dbm "github.com/tendermint/tmlibs/db"
-	crypto "github.com/tendermint/go-crypto"
+	//crypto "github.com/tendermint/go-crypto"
 	cmn "github.com/tendermint/tmlibs/common"
 	"github.com/tendermint/tmlibs/log"
-	//"../types" //should be adjusted to reference our repo
-	//"../utxo"
-	"fmt" //for testing
-	"github.com/ethereum/go-ethereum/rlp"
+	types "plasma-mvp-sidechain/types" 
+	//"fmt" //for testing
+	//"github.com/ethereum/go-ethereum/rlp"
 
 )
 
@@ -31,8 +30,7 @@ type ChildChain struct {
 	capKeyIBCStore *sdk.KVStoreKey //capabilities key to access IBC Store from multistore
 
 	// Manage addition and deletion of unspent utxo's 
-	// TODO: Add utxo mapper here
-	uxtoMapper utxoMapper
+	utxoMapper types.UtxoMapper
 }
 
 func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
@@ -43,16 +41,16 @@ func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 	}
 
 	// define the utxoMapper
-	app.utxoMapper = NewUTXOMapper(
+	app.utxoMapper = types.NewUTXOMapper(
 		app.capKeyMainStore, // target store
-		&BaseUTXO{},
+		&types.BaseUTXO{},
 	)
 
 	// TODO: add handlers/router
 	// UTXOKeeper to adjust spending and recieving of utxo's
-	UTXOKeeper := NewUTXOKeeper(app.utxoMapper)
+	UTXOKeeper := types.NewUTXOKeeper(app.utxoMapper)
 	app.Router().
-		AddRoute("txs", NewHandler(UTXOKeeper))
+		AddRoute("txs", types.NewHandler(UTXOKeeper))
 
 	// initialize BaseApp
 	// set the BaseApp txDecoder to use txDecoder with RLP
@@ -77,19 +75,14 @@ func NewChildChain(logger log.Logger, db dbm.DB) *ChildChain {
 // TODO: change sdk.Tx to different transaction struct
 func (app *ChildChain) txDecoder(txBytes []byte) (sdk.Tx, sdk.Error) {
 	// TODO: implement method
-	return nil
+	return nil, nil
 }
 
 // TODO: Add initChainer?
-
-// TODO: delete this
-func main() {
-	fmt.Println("Compiled")
-}
 
 
 
 // Current big idea TODO List:
 // - Implement RLP Encoding/Decoding in app.go and tx.go
-// 4. Implement AnteHandler
-// 5. Write Basic Test Cases
+// - Implement AnteHandler
+// - Write Basic Test Cases

--- a/app/app.go
+++ b/app/app.go
@@ -13,7 +13,7 @@ import (
 	"github.com/tendermint/tmlibs/log"
 
 	"github.com/tendermint/go-amino" // Not necessary once switched to RLP
-	//"github.com/ethereum/go-ethereum/rlp" // TODO: Change from amino to RLP
+	rlp "github.com/ethereum/go-ethereum/rlp" // TODO: Change from amino to RLP
 
 )
 
@@ -82,9 +82,9 @@ func (app *ChildChain) txDecoder(txBytes []byte) (sdk.Tx, sdk.Error) {
 	// TODO: implement method with RLP
 	var tx = types.BaseTx{}
 	// BaseTx is struct for Msg wrapped with authentication data
-	err := app.cdc.UnmarshalBinary(txBytes, &tx)
+	err := rlp.DecodeBytes(txBytes, &tx)
 	if err != nil {
-		return nil, sdk.ErrTxParse("").TraceCause(err, "")
+		return nil, sdk.ErrTxDecode("").TraceCause(err, "")
 	}
 	return tx, nil
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -13,7 +13,6 @@ import (
 	types "plasma-mvp-sidechain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types" 
 	//rlp "github.com/ethereum/go-ethereum/rlp"
-
 )
 
 func newChildChain() *ChildChain {
@@ -51,6 +50,7 @@ func TestDepositMsg(t *testing.T) {
 	
 	cdc := MakeCodec()
 	txBytes, err := cdc.MarshalBinary(tx)
+
 	require.NoError(t, err)
 
 	// Run a check 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -12,6 +12,7 @@ import (
 	abci "github.com/tendermint/abci/types"
 	types "plasma-mvp-sidechain/types"
 	sdk "github.com/cosmos/cosmos-sdk/types" 
+	//rlp "github.com/ethereum/go-ethereum/rlp"
 
 )
 
@@ -21,7 +22,7 @@ func newChildChain() *ChildChain {
 	return NewChildChain(logger, db)
 }
 
-func TestSpendMsg(t *testing.T) {
+func TestDepositMsg(t *testing.T) {
 	cc := newChildChain()
 	
 	// Construct a SpendMsg
@@ -41,25 +42,25 @@ func TestSpendMsg(t *testing.T) {
 		Fee: 1,
 	}
 
-	priv := crypto.GenPrivKeyEd25519()
+	priv := crypto.GenPrivKeySecp256k1()
 	sig := priv.Sign(msg.GetSignBytes())
 	tx := types.NewBaseTx(msg, []sdk.StdSignature {{
 			PubKey: 	priv.PubKey(),
 			Signature:	sig,
 		}})
-	//Change to RLP once implemented
+	
 	cdc := MakeCodec()
-	txBytes, err:= cdc.MarshalBinary(tx)
+	txBytes, err := cdc.MarshalBinary(tx)
 	require.NoError(t, err)
 
 	// Run a check 
 	cres := cc.CheckTx(txBytes)
-	assert.Equal(t, sdk.CodeType(101),
+	assert.Equal(t, sdk.CodeType(100),
 				sdk.CodeType(cres.Code), cres.Log)
 
 	// Simulate a Block
 	cc.BeginBlock(abci.RequestBeginBlock{})
 	dres := cc.DeliverTx(txBytes)
-	assert.Equal(t, sdk.CodeType(101), sdk.CodeType(dres.Code), dres.Log)
+	assert.Equal(t, sdk.CodeType(100), sdk.CodeType(dres.Code), dres.Log)
 
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -3,10 +3,16 @@ package app
 import (
 	"os"
 	"testing"
-	"fmt"
+	//"fmt" //for debugging
 	dbm "github.com/tendermint/tmlibs/db"
 	"github.com/tendermint/tmlibs/log"
-	//types "plasma-mvp-sidechain/types" 
+	crypto "github.com/tendermint/go-crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/abci/types"
+	types "plasma-mvp-sidechain/types"
+	sdk "github.com/cosmos/cosmos-sdk/types" 
+
 )
 
 func newChildChain() *ChildChain {
@@ -16,8 +22,44 @@ func newChildChain() *ChildChain {
 }
 
 func TestSpendMsg(t *testing.T) {
-	//cc := newChildChain()
-	fmt.Println("Testing has commenced")
+	cc := newChildChain()
+	
 	// Construct a SpendMsg
-	//var msg = types.SpendMsg{}
+	var msg = types.SpendMsg{
+		Blknum1: 0,
+		Txindex1: 0,
+		Oindex1: 0,
+		Owner1:crypto.Address([]byte("origin")),
+		Blknum2: 0,
+		Txindex2:0,
+		Oindex2:0,
+		Owner2: crypto.Address([]byte("")),
+		Newowner1: crypto.Address([]byte("recipient")),
+		Denom1: 1000,
+		Newowner2:crypto.Address([]byte("")),
+		Denom2:0,
+		Fee: 1,
+	}
+
+	priv := crypto.GenPrivKeyEd25519()
+	sig := priv.Sign(msg.GetSignBytes())
+	tx := types.NewBaseTx(msg, []sdk.StdSignature {{
+			PubKey: 	priv.PubKey(),
+			Signature:	sig,
+		}})
+	//Change to RLP once implemented
+	cdc := MakeCodec()
+	txBytes, err:= cdc.MarshalBinary(tx)
+	require.NoError(t, err)
+
+	// Run a check 
+	cres := cc.CheckTx(txBytes)
+	assert.Equal(t, sdk.CodeType(101),
+				sdk.CodeType(cres.Code), cres.Log)
+
+	// Simulate a Block
+	cc.BeginBlock(abci.RequestBeginBlock{})
+	dres := cc.DeliverTx(txBytes)
+	assert.Equal(t, sdk.CodeType(101), sdk.CodeType(dres.Code), dres.Log)
+
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"os"
+	"testing"
+	"fmt"
+	dbm "github.com/tendermint/tmlibs/db"
+	"github.com/tendermint/tmlibs/log"
+	//types "plasma-mvp-sidechain/types" 
+)
+
+func newChildChain() *ChildChain {
+	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "sdk/app")
+	db := dbm.NewMemDB()
+	return NewChildChain(logger, db)
+}
+
+func TestSpendMsg(t *testing.T) {
+	//cc := newChildChain()
+	fmt.Println("Testing has commenced")
+	// Construct a SpendMsg
+	//var msg = types.SpendMsg{}
+}

--- a/types/ante.go
+++ b/types/ante.go
@@ -1,0 +1,179 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/viper"
+)
+
+// NewAnteHandler returns an AnteHandler that checks signatures,
+// and deducts fees from the first signer.
+
+// TODO: what kind of Mapper to take in as param?
+func NewAnteHandler(utxoMapper UTXOMapper) sdk.AnteHandler {
+	return func(ctx sdk.Context, tx sdk.Tx,)
+	(_ sdk.Context, _ sdk.Result, abort bool) 
+	{
+
+		// TODO: figure out Go syntax: tx.()
+		baseTx, ok := tx.(BaseTx)
+		if !ok {
+			return ctx, sdk.ErrInternal("tx must be type BaseTx").Result(), true
+		}
+
+		sigs := tx.getSignatures()
+		if len(sigs) == 0 {
+			return ctx,
+				sdk.ErrUnauthorized("no signers").Result(),
+				true
+		}
+
+
+		msg := tx.GetMsg()
+
+		// Assert that number of signatures is correct.
+		// GetSigners returns list of crypto.Address
+		var signerAddrs = msg.GetSigners()
+		if len(sigs) != len(signerAddrs) {
+			return ctx,
+				sdk.ErrUnauthorized("wrong number of signers").Result(),
+				true
+		}
+
+		// TODO: calculate sum(msg input) = sum(msg output) + fee
+		owner1 := msg.Owner1
+		position1 := [3]uint{msg.Blknum1, msg.Txindex1, msg.Oindex1}
+		utxo1 := utxoMapper.GetUTXO(ctx, owner1, position1)
+		if utxo1 == (BaseUTXO{}) {
+			// TODO: return error
+		}
+
+		owner2 := msg.Owner2
+		position2 := [3]uint{msg.Blknum2, msg.Txindex2, msg.Oindex2}
+		utxo2 := utxoMapper.GetUTXO(ctx, owner2, position2)
+		if utxo2 == (BaseUTXO{}) {
+			// TODO: return error
+		}
+
+		// check that the sum of inputs is greater than sum of outputs
+		// Should we still include fee in SpendMsg
+		if utxo1.GetDenom() + utxo2.GetDenom() != msg.Denom1 + msg.Denom2 + msg.fee {
+			// TODO: return error
+		}
+
+
+
+		// Get the sign bytes (requires all sequence numbers and the fee)
+		// sequences := make([]int64, len(signerAddrs))
+		// for i := 0; i < len(signerAddrs); i++ {
+			// sequences[i] = sigs[i].Sequence
+		// }
+
+		// fee := stdTx.Fee
+
+		// XXX: major hack; need to get ChainID
+		// into the app right away (#565)
+		// LL: not sure what ChainID and viper is?
+		// chainID := ctx.ChainID()
+		// if chainID == "" {
+		// 	chainID = viper.GetString("chain-id")
+		// }
+
+		// // signBytes := sdk.StdSignBytes(ctx.ChainID(), sequences, fee, msg)
+		// signBytes := msg.GetSignBytes()
+
+
+		// // Check sig and nonce and collect signer accounts.
+		// // LL: probably need to make these into UTXOs instead?
+		// var signerAccs = make([]sdk.Account, len(signerAddrs))
+		// for i := 0; i < len(sigs); i++ {
+		// 	signerAddr, sig := signerAddrs[i], sigs[i]
+
+		// 	// check signature, return account with incremented nonce
+		// 	signerAcc, res := processSig(
+		// 		ctx, accountMapper,
+		// 		signerAddr, sig, signBytes,
+		// 	)
+		// 	if !res.IsOK() {
+		// 		return ctx, res, true
+		// 	}
+
+		// 	// first sig pays the fees
+		// 	if i == 0 {
+		// 		// TODO: min fee
+		// 		if !fee.Amount.IsZero() {
+		// 			signerAcc, res = deductFees(signerAcc, fee)
+		// 			if !res.IsOK() {
+		// 				return ctx, res, true
+		// 			}
+		// 		}
+		// 	}
+
+		// 	// Save the account.
+		// 	accountMapper.SetAccount(ctx, signerAcc)
+		// 	signerAccs[i] = signerAcc
+		// }
+
+		// // cache the signer accounts in the context
+		// // LL: WithSigners is only used for testing!! (see x/auth/context_test.go)
+		// ctx = WithSigners(ctx, signerAccs)
+
+		// // TODO: tx tags (?)
+
+		// return ctx, sdk.Result{}, false // continue...
+
+
+
+	}
+}
+
+
+// verify the signature and increment the sequence.
+// if the account doesn't have a pubkey, set it.
+func processSig(
+	ctx sdk.Context, um UTXOMapper,
+	addr sdk.Address, sig sdk.StdSignature, signBytes []byte) {
+
+	// // Get the account.
+	// acc = am.GetAccount(ctx, addr)
+	// if acc == nil {
+	// 	return nil, sdk.ErrUnknownAddress(addr.String()).Result()
+	// }
+
+	// // Check and increment sequence number.
+	// seq := acc.GetSequence()
+	// if seq != sig.Sequence {
+	// 	return nil, sdk.ErrInvalidSequence(
+	// 		fmt.Sprintf("Invalid sequence. Got %d, expected %d", sig.Sequence, seq)).Result()
+	// }
+	// acc.SetSequence(seq + 1)
+
+	// If pubkey is not known for account,
+	// set it from the StdSignature.
+
+	pubKey = sig.PubKey
+	if pubKey.Empty() {
+		return nil, sdk.ErrInvalidPubKey("PubKey not found").Result()
+	}
+
+	if !bytes.Equal(pubKey.Address(), addr) {
+		return nil, sdk.ErrInvalidPubKey(
+			fmt.Sprintf("PubKey does not match Signer address %v", addr)).Result()
+	}
+	err := acc.SetPubKey(pubKey)
+	if err != nil {
+		return nil, sdk.ErrInternal("setting PubKey on signer's account").Result()
+	}
+
+
+	// Check sig.
+	if !pubKey.VerifyBytes(signBytes, sig.Signature) {
+		return nil, sdk.ErrUnauthorized("signature verification failed").Result()
+	}
+
+	return
+}
+
+
+
+
+

--- a/types/handler.go
+++ b/types/handler.go
@@ -1,8 +1,8 @@
 package types
 
 import (
-	"reflect"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"reflect"
 )
 
 // Handle all "bank" type messages.

--- a/types/handler.go
+++ b/types/handler.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+	"reflect"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Handle all "bank" type messages.
+func NewHandler(uk UTXOKeeper) sdk.Handler {
+	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
+		switch msg := msg.(type) {
+		case SpendMsg:
+			return handleSpendMsg(ctx, uk, msg)
+		case DepositMsg:
+			return handleDepositMsg(ctx, uk, msg)
+		default:
+			errMsg := "Unrecognized Msg type: " + reflect.TypeOf(msg).Name()
+			return sdk.ErrUnknownRequest(errMsg).Result()
+		}
+	}
+}
+
+// Handle SendMsg.
+func handleSpendMsg(ctx sdk.Context, uk UTXOKeeper, msg SpendMsg) sdk.Result {
+	// NOTE: totalIn == totalOut should already have been checked
+	// TODO: Implement
+	panic("not implemented yet")
+
+	// TODO: add some tags so we can search it!
+	return sdk.Result{} // TODO
+}
+
+// Handle IssueMsg.
+func handleDepositMsg(ctx sdk.Context, uk UTXOKeeper, msg DepositMsg) sdk.Result {
+	// TODO: Implement 
+	panic("not implemented yet")
+}

--- a/types/handler.go
+++ b/types/handler.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"math/big"
 	"reflect"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -26,14 +27,16 @@ func handleSpendMsg(ctx sdk.Context, uk UTXOKeeper, msg SpendMsg) sdk.Result {
 	// TODO: Implement
 	if msg.Owner1 != nil {
 		//CHANGE
-		err := uk.SpendUTXO(ctx, msg.Owner1, msg.Denom1)
+		position := [3]uint{msg.Blknum1, msg.Txindex1, msg.Oindex1}
+		err := uk.SpendUTXO(ctx, msg.Owner1, position)
 		if err != nil {
 			return err.Result()
 		}
 	}
 	if msg.Owner2 != nil {
 		//CHANGE
-		err := uk.SpendUTXO(ctx, msg.Owner2, msg.Denom2)
+		position := [3]uint{msg.Blknum2, msg.Txindex2, msg.Oindex2}
+		err := uk.SpendUTXO(ctx, msg.Owner2, position)
 		if err != nil {
 			return err.Result()
 		}
@@ -57,5 +60,19 @@ func handleSpendMsg(ctx sdk.Context, uk UTXOKeeper, msg SpendMsg) sdk.Result {
 // Handle IssueMsg.
 func handleDepositMsg(ctx sdk.Context, uk UTXOKeeper, msg DepositMsg) sdk.Result {
 	// TODO: Implement 
+	return sdk.Result{}
+}
+
+func handleFinalizeMsg(ctx sdk.Context, uk UTXOKeeper, msg FinalizeMsg) sdk.Result {
+	err := uk.FinalizeUTXO(ctx, msg.Spend.Newowner1, msg.Spend.Denom1, msg.Position, msg.ConfirmSigs)
+	if err != nil {
+		return sdk.NewError(100, err.Error()).Result()
+	}
+	if msg.Spend.Newowner2 != nil && new(big.Int).SetBytes(msg.Spend.Newowner2).Sign() != 0 {
+		err = uk.FinalizeUTXO(ctx, msg.Spend.Newowner2, msg.Spend.Denom2, msg.Position, msg.ConfirmSigs)
+	}
+	if err != nil {
+		return sdk.NewError(100, err.Error()).Result()
+	}
 	return sdk.Result{}
 }

--- a/types/handler.go
+++ b/types/handler.go
@@ -24,8 +24,32 @@ func NewHandler(uk UTXOKeeper) sdk.Handler {
 func handleSpendMsg(ctx sdk.Context, uk UTXOKeeper, msg SpendMsg) sdk.Result {
 	// NOTE: totalIn == totalOut should already have been checked
 	// TODO: Implement
-	panic("not implemented yet")
-
+	if msg.Owner1 != nil {
+		//CHANGE
+		err := uk.SpendUTXO(ctx, msg.Owner1, msg.Denom1)
+		if err != nil {
+			return err.Result()
+		}
+	}
+	if msg.Owner2 != nil {
+		//CHANGE
+		err := uk.SpendUTXO(ctx, msg.Owner2, msg.Denom2)
+		if err != nil {
+			return err.Result()
+		}
+	}
+	if msg.Newowner1 != nil {
+		err := uk.RecieveUTXO(ctx, msg.Newowner1, msg.Denom1)
+		if err != nil {
+			return err.Result()
+		}
+	}
+	if msg.Newowner2 != nil {
+		err := uk.RecieveUTXO(ctx, msg.Newowner2, msg.Denom2)
+		if err != nil {
+			return err.Result()
+		}
+	}
 	// TODO: add some tags so we can search it!
 	return sdk.Result{} // TODO
 }
@@ -33,5 +57,5 @@ func handleSpendMsg(ctx sdk.Context, uk UTXOKeeper, msg SpendMsg) sdk.Result {
 // Handle IssueMsg.
 func handleDepositMsg(ctx sdk.Context, uk UTXOKeeper, msg DepositMsg) sdk.Result {
 	// TODO: Implement 
-	panic("not implemented yet")
+	return sdk.Result{}
 }

--- a/types/mapper.go
+++ b/types/mapper.go
@@ -5,12 +5,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	amino "github.com/tendermint/go-amino"
 	crypto "github.com/tendermint/go-crypto"
-	"reflect"
 )
 
 // Manages utxo's in existence
 // Uses go-amino encoding/decoding library
-// Does not need to be changed to RLP
 type UTXOMapper struct {
 
 	// The contextKey used to access the store from the Context.
@@ -19,34 +17,29 @@ type UTXOMapper struct {
 	// The Key required to access store with all confirmSigs. Persists throughout application
 	sigKey sdk.StoreKey
 
-	// The prototypical UTXO concrete type
-	proto UTXOHolder
-
 	// The Amino codec for binary encoding/decoding of utxo's
 	cdc *amino.Codec
 }
 
 // NewUTXOMapper returns a new UtxoMapper that
 // uses go-Amino to (binary) encode and decode concrete UTXO
-func NewUTXOMapper(contextKey sdk.StoreKey, sigKey sdk.StoreKey, proto UTXOHolder) UTXOMapper {
+func NewUTXOMapper(contextKey sdk.StoreKey, sigKey sdk.StoreKey) UTXOMapper {
 	cdc := amino.NewCodec()
 	Register(cdc)
 	return UTXOMapper{
 		contextKey: contextKey,
 		sigKey:     sigKey,
-		proto:      proto,
 		cdc:        cdc,
 	}
 
 }
 
 // Create and return a sealed utxo mapper. Not sure if necessary
-func NewUTXOMapperSealed(contextKey sdk.StoreKey, sigKey sdk.StoreKey, proto UTXOHolder) sealedUTXOMapper {
+func NewUTXOMapperSealed(contextKey sdk.StoreKey, sigKey sdk.StoreKey) sealedUTXOMapper {
 	cdc := amino.NewCodec()
 	um := UTXOMapper{
 		contextKey: contextKey,
 		sigKey:     sigKey,
-		proto:      proto,
 		cdc:        cdc,
 	}
 	// Register for amino encoding/decoding
@@ -58,14 +51,7 @@ func NewUTXOMapperSealed(contextKey sdk.StoreKey, sigKey sdk.StoreKey, proto UTX
 
 // Register all crypto interfaces and concrete types necessary
 func Register(cdc *amino.Codec) {
-	cdc.RegisterConcrete(crypto.PubKey{}, "go-crypto/PubKey", nil)
-	cdc.RegisterConcrete(crypto.PrivKey{}, "go-crypto/PrivKey", nil)
-	cdc.RegisterConcrete(crypto.Signature{}, "go-crypto/Signature", nil)
-	cdc.RegisterConcrete(sdk.StdSignature{}, "sdk/StdSignature", nil)
-	cdc.RegisterInterface((*crypto.PubKeyInner)(nil), nil)
-	cdc.RegisterConcrete(crypto.PubKeyEd25519{}, "go-crypto/PubKeyEd25519", nil)
-	cdc.RegisterConcrete(crypto.SignatureEd25519{}, "go-crypto/SignatureEd25519", nil)
-	cdc.RegisterInterface((*crypto.SignatureInner)(nil), nil)
+	crypto.RegisterAmino(cdc)
 	cdc.RegisterInterface((*UTXOHolder)(nil), nil)
 	cdc.RegisterInterface((*UTXO)(nil), nil)
 	cdc.RegisterConcrete(BaseUTXOHolder{}, "types/BaseUTXOHolder", nil)
@@ -170,47 +156,6 @@ func (sum sealedUTXOMapper) AminoCodec() *amino.Codec {
 	panic("utxoMapper is sealed")
 }
 
-//----------------------------------------
-// misc.
-
-func (um UTXOMapper) clonePrototypePtr() interface{} {
-	protoRt := reflect.TypeOf(um.proto)
-	if protoRt.Kind() == reflect.Ptr {
-		protoErt := protoRt.Elem()
-		if protoErt.Kind() != reflect.Struct {
-			panic("utxoMapper requires a struct proto UTXO, or a pointer to one")
-		}
-		protoRv := reflect.New(protoErt)
-		return protoRv.Interface()
-	} else {
-		protoRv := reflect.New(protoRt)
-		return protoRv.Interface()
-	}
-}
-
-// Creates a new struct (or pointer to struct) from um.proto.
-func (um UTXOMapper) clonePrototype() UTXOHolder {
-	protoRt := reflect.TypeOf(um.proto)
-	if protoRt.Kind() == reflect.Ptr {
-		protoCrt := protoRt.Elem()
-		if protoCrt.Kind() != reflect.Struct {
-			panic("utxoMapper requires a struct proto UTXOHolder, or a pointer to one")
-		}
-		protoRv := reflect.New(protoCrt)
-		clone, ok := protoRv.Interface().(UTXOHolder)
-		if !ok {
-			panic(fmt.Sprintf("utxoMapper requires a proto UTXO, but %v doesn't implement UTXO", protoRt))
-		}
-		return clone
-	} else {
-		protoRv := reflect.New(protoRt).Elem()
-		clone, ok := protoRv.Interface().(UTXOHolder)
-		if !ok {
-			panic(fmt.Sprintf("utxoMapper requires a proto UTXOHolder, but %v doesn't implement UTXO", protoRt))
-		}
-		return clone
-	}
-}
 
 func (um UTXOMapper) encodeUTXOHolder(uh UTXOHolder) []byte {
 	bz, err := um.cdc.MarshalBinary(uh)
@@ -221,16 +166,12 @@ func (um UTXOMapper) encodeUTXOHolder(uh UTXOHolder) []byte {
 }
 
 func (um UTXOMapper) decodeUTXOHolder(bz []byte) UTXOHolder {
-	uhPtr := um.clonePrototypePtr()
-	err := um.cdc.UnmarshalBinary(bz, uhPtr)
+	utxoHolder := &BaseUTXOHolder{}
+	err := um.cdc.UnmarshalBinary(bz, utxoHolder)
 	if err != nil {
 		panic(err)
 	}
-	if reflect.ValueOf(um.proto).Kind() == reflect.Ptr {
-		return reflect.ValueOf(uhPtr).Interface().(UTXOHolder)
-	} else {
-		return reflect.ValueOf(uhPtr).Elem().Interface().(UTXOHolder)
-	}
+	return utxoHolder
 }
 
 //----------------------------------------

--- a/types/mapper.go
+++ b/types/mapper.go
@@ -1,0 +1,163 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	crypto "github.com/tendermint/go-crypto"
+	"utxo"
+	"reflect"
+	wire "github.com/tendermint/go-wire"
+)
+
+// Implements UTXOMapper
+
+type utxoMapper struct {
+	
+	// The key used to access the store from the Context.
+	key sdk.StoreKey
+
+	// The prototypical UTXO concrete type
+	proto UTXO
+
+	// The wire codec for binary encoding/decoding of utxo's 
+	cdc *wire.Codec 
+}
+
+// NewUTXOMapper returns a new utxoMapper that
+// uses go-wire to (binary) encode and decode concrete UTXO
+func NewUTXOMapper(key sdk.StoreKey, proto UTXO) utxoMapper {
+	cdc := wire.NewCodec()
+	return utxoMapper {
+		key:   key,
+		proto: proto,
+		cdc:   cdc, 
+	}
+}
+
+// Create and return a sealed utxo mapper. Not sure if necessary
+func NewUTXOMapperSealed(key sdk.StoreKey, proto UTXO) sealedUTXOMapper {
+	cdc := wire.NewCodec()
+	// um is utxo mapper
+	um := utxoMapper {
+		key:   key,	
+		proto: proto,
+		cdc:   cdc,
+	}
+	// ISSUE: something about register wire here?
+
+	// make accountMapper's WireCodec() inaccessible, return
+	return um.Seal()
+}
+
+// Returns the go-wire codec.
+func (um utxoMapper) WireCodec() *wire.Codec {
+	return um.cdc
+}
+
+// Returns a "sealed" utxoMapper
+// the codec is not accessible from a sealedUTXOMapper
+func (um utxoMapper) Seal() sealedUTXOMapper {
+	return sealedUTXOMapper{um}
+}
+
+// Implements UTXO
+func (um utxoMapper) GetUTXO(ctx Context, pubkey crypto.PubKey) UTXO {
+	store := ctx.KVStore(um.key)
+	bz := store.Get(pubkey)
+	if bz == nil {
+		return nil
+	}
+	utxo := um.decodeUTXO(bz)
+	return utxo
+}
+
+//Implements UTXO
+func (um utxoMapper) CreateUTXO(ctx Context, utxo UTXO) {
+	pk := utxo.GetPubKey()
+	store := ctx.KVStore(um.key)
+	bz := um.encodeUTXO(utxo)
+	store.Set(pk, bz)
+}
+
+//Implements UTXO
+func (um utxoMapper) DestroyUTXO(ctx Context, utxo UTXO) {
+	pk := utxo.GetPubKey()
+	store := ctx.KVStore(um.key)
+	bz := store.Get(pk)
+	store.Delete(bz)
+}
+
+//----------------------------------------
+// sealedUTXOMapper
+
+func sealedUTXOMapper struct {
+	utxoMapper
+}
+
+// There's no way for external modules to mutate the 
+// sum.utxoMapper.ctx from here, even with reflection
+func (sum sealedUTXOMapper) WireCodec() *wire.Codec {
+	panic("utxoMapper is sealed")
+}
+
+//----------------------------------------
+// misc.
+
+func (um utxoMapper) clonePrototypePtr() interface{} {
+	protoRt := reflect.TypeOf(um.proto)
+	if protoRt.Kind() == reflect.Ptr {
+		protoErt := protoRt.Elem()
+		if protoErt.Kind() != reflect.Struct {
+			panic("utxoMapper requires a struct proto UTXO, or a pointer to one")
+		}
+		protoRv := reflect.New(protoErt)
+		return protoRv.Interface()
+	} else {
+		protoRv := reflect.New(protoRt)
+		return protoRv.Interface()
+	}
+}
+
+// Creates a new struct (or pointer to struct) from um.proto.
+func (um utxoMapper) clonePrototype() sdk.Account {
+	protoRt := reflect.TypeOf(um.proto)
+	if protoRt.Kind() == reflect.Ptr {
+		protoCrt := protoRt.Elem()
+		if protoCrt.Kind() != reflect.Struct {
+			panic("utxoMapper requires a struct proto UTXO, or a pointer to one")
+		}
+		protoRv := reflect.New(protoCrt)
+		clone, ok := protoRv.Interface().(UTXO)
+		if !ok {
+			panic(fmt.Sprintf("utxoMapper requires a proto UTXO, but %v doesn't implement UTXO", protoRt))
+		}
+		return clone
+	} else {
+		protoRv := reflect.New(protoRt).Elem()
+		clone, ok := protoRv.Interface().(UTXO)
+		if !ok {
+			panic(fmt.Sprintf("utxoMapper requires a proto UTXO, but %v doesn't implement UTXO", protoRt))
+		}
+		return clone
+	}
+}
+
+func (um utxoMapper) encodeUTXO(utxo UTXO) []byte {
+	bz, err := um.cdc.MarshalBinary(utxo)
+	if err != nil {
+		panic(err)
+	}
+	return bz
+}
+
+func (um utxoMapper) decodeUTXO(bz []byte) UTXO {
+	utxoPtr := um.clonePrototypePtr()
+	err := um.cdc.UnmarshalBinary(bz, utxoPtr)
+	if err != nil {
+		panic(err)
+	}
+	if reflect.ValueOf(um.proto).Kind() == reflect.Ptr {
+		return reflect.ValueOf(utxoPtr).Interface().(UTXO)
+	} else {
+		return reflect.ValueOf(utxoPtr).Elem().Interface().(UTXO)
+	}
+}

--- a/types/mapper.go
+++ b/types/mapper.go
@@ -62,6 +62,7 @@ func Register(cdc *amino.Codec) {
 	cdc.RegisterConcrete(crypto.SignatureEd25519{}, "go-crypto/SignatureEd25519", nil)
 	cdc.RegisterInterface((*crypto.SignatureInner)(nil), nil)
 	cdc.RegisterInterface((*UTXOHolder)(nil), nil)
+	cdc.RegisterInterface((*UTXO)(nil), nil)
 	cdc.RegisterConcrete(BaseUTXOHolder{}, "types/BaseUTXOHolder", nil)
 }
 

--- a/types/mapper.go
+++ b/types/mapper.go
@@ -236,6 +236,7 @@ func (uk UTXOKeeper) SpendUTXO(ctx sdk.Context, addr crypto.Address, position [3
 	if utxo == nil {
 		return sdk.NewError(101, "Unrecognized UTXO. Does not exist.")
 	}
+	fmt.Println(utxo)
 	uk.um.DestroyUTXO(ctx, utxo) // Delete utxo from utxo store
 	return nil
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -3,7 +3,6 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	crypto "github.com/tendermint/go-crypto"
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // Consider correct types to use
@@ -25,7 +24,7 @@ type SpendMsg struct {
 	fee       uint
 }
 
-func NewSpendMsg(blknum1 uint, txindex1 uint, oindex1, owner1 crypto.Address uint, blknum2 uint, txindex2 uint, oindex2 uint, owner2 crypto.Address,
+func NewSpendMsg(blknum1 uint, txindex1 uint, oindex1 uint, owner1 crypto.Address, blknum2 uint, txindex2 uint, oindex2 uint, owner2 crypto.Address,
 				newowner1 crypto.Address, denom1 uint, newowner2 crypto.Address, denom2 uint, fee uint) SpendMsg {
 	return SpendMsg{
 		blknum1: 	blknum1,
@@ -51,8 +50,8 @@ func (msg SpendMsg) Type() string { return "txs" } // TODO: decide on something 
 func (msg SpendMsg) ValidateBasic() sdk.Error {
 	// this just ensures everything is correctly formatted
 	// Add more checks?
-	if msg.newowner1 == 0 && msg.newowner2 == 0 {
-		return NewError(10,"No recipient of transaction")
+	if msg.newowner1 == nil && msg.newowner2 == nil {
+		return sdk.NewError(10,"No recipient of transaction")
 	}
 	return nil
 }
@@ -126,17 +125,17 @@ func (msg DepositMsg) GetSigners() []crypto.Address {
 // BaseTx (Transaction wrapper for depositmsg and spendmsg)
 
 type BaseTx struct {
-	Msg
-	Signatures []StdSignature
+	sdk.Msg
+	Signatures []sdk.StdSignature
 }
 
-func NewStdTx(msg Msg, sigs []StdSignature) BaseTx {
+func NewStdTx(msg sdk.Msg, sigs []sdk.StdSignature) BaseTx {
 	return BaseTx{
 		Msg: 		msg,
 		Signatures: sigs,
 	}
 }
 
-func (tx BaseTx) GetMsg() Msg 					{ return tx.Msg }
+func (tx BaseTx) GetMsg() sdk.Msg 					{ return tx.Msg }
 func (tx BaseTx) GetFeePayer() crypto.Address	{ return tx.Signatures[0].PubKey.Address() }
-func (tx BaseTx) GetSignatures() []StdSignature { return tx.Signatures }
+func (tx BaseTx) GetSignatures() []sdk.StdSignature { return tx.Signatures }

--- a/types/tx.go
+++ b/types/tx.go
@@ -1,0 +1,107 @@
+package types
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	crypto "github.com/tendermint/go-crypto"
+)
+
+// Consider correct types to use
+// Also consider changing to have input/output structs. Not sure how 
+// would work with rootContract
+type SpendMsg struct {
+	blknum1   uint
+	txindex1  uint
+	oindex1   uint
+	blknum2   uint
+	txindex2  uint
+	oindex2   uint
+	newowner1 crypto.Address
+	denom1    uint
+	newowner2  crypto.Address
+	denom2    uint
+	fee       uint
+}
+
+func NewSpendMsg(blknum1 uint, txindex1 uint, oindex1 uint, blknum2 uint, txindex2 uint, oindex2 uint,
+				newowner1 crypto.Address, denom1 uint, newowner2 crypto.Address, denom2 uint, fee uint) SpendMsg {
+	return SpendMsg{
+		blknum1: 	blknum1,
+		txindex1: 	txindex1,
+		oindex1:	oindex1,
+		blknum2:	blknum2,
+		txindex2:	txindex2,
+		oindex2:	oindex2,
+		newowner1:	newowner1,
+		denom1:		denom1,
+		newowner2:	newowner2,
+		denom2:		denom2,
+		fee:		fee,
+	}
+}
+
+// Implements Msg.
+func (msg SpendMsg) Type() string { return "txs" } // TODO: decide on something better
+
+// Implements Msg.
+func (msg SpendMsg) ValidateBasic() sdk.Error {
+	// this just ensures everything is correctly formatted
+
+}
+
+// Implements Msg. 
+func (msg SpendMsg) String() string {
+	return "Spend" // TODO: Implement so contents of Msg are returned
+}
+
+// Implements Msg.
+func (msg SpendMsg) Get(key interface{}) (value interface{}) {
+	return nil // TODO: Implement 
+}
+
+// Implements Msg.
+func (msg SpendMsg) GetSignBytes() []byte {
+	// TODO
+}
+
+// Implements Msg.
+func (msg SpendMsg) GetSigners() []crypto.Address {
+	// TODO
+}
+
+//----------------------------------------
+// DepositMsg
+
+//Consider changing rootchain contract
+type DepositMsg struct {
+	owner 	crypto.Address
+	denom 	uint
+}
+
+// Implements Msg.
+func (msg DepositMsg) Type() string { return "txs" } // TODO: decide on something better
+
+// Implements Msg.
+func (msg DepositMsg) ValidateBasic() sdk.Error {
+	// this just ensures everything is correctly formatted
+
+}
+
+// Implements Msg. 
+func (msg DepositMsg) String() string {
+	return "Spend" // TODO: Implement so contents of Msg are returned
+}
+
+// Implements Msg.
+func (msg DepositMsg) Get(key interface{}) (value interface{}) {
+	return nil // TODO: Implement 
+}
+
+// Implements Msg.
+func (msg DepositMsg) GetSignBytes() []byte {
+	// TODO
+}
+
+// Implements Msg.
+func (msg DepositMsg) GetSigners() []crypto.Address {
+	// TODO
+}

--- a/types/tx.go
+++ b/types/tx.go
@@ -8,8 +8,6 @@ import (
 )
 
 // Consider correct types to use
-// Also consider changing to have input/output structs. Not sure how
-// would work with rootContract
 // ConfirmSigs1 has confirm signatures from spenders of transaction located at [Blknum1, Txindex1, Oindex1] with signatures in order
 // ConfirmSigs2 has confirm signatures from spenders of transaction located at [Blknum2, Txindex2, Oindex2] with signatures in order
 type SpendMsg struct {
@@ -125,7 +123,7 @@ func (msg SpendMsg) IsDeposit() bool {
 
 // Implements Msg.
 func (msg SpendMsg) String() string {
-	return "Spend" // TODO: Implement so contents of Msg are returned
+	return "Spend" // TODO: Issue #3
 }
 
 // Implements Msg.
@@ -135,7 +133,6 @@ func (msg SpendMsg) Get(key interface{}) (value interface{}) {
 
 // Implements Msg.
 func (msg SpendMsg) GetSignBytes() []byte {
-	// TODO: Implement with RLP encoding
 	b, err := rlp.EncodeToBytes(msg)
 	if err != nil {
 		panic(err)
@@ -145,7 +142,6 @@ func (msg SpendMsg) GetSignBytes() []byte {
 
 // Implements Msg.
 func (msg SpendMsg) GetSigners() []crypto.Address {
-	// TODO
 	addrs := make([]crypto.Address, 1)
 	addrs[0] = crypto.Address(msg.Owner1)
 	if !ZeroAddress(msg.Owner2) {
@@ -173,7 +169,7 @@ func (msg FinalizeMsg) Type() string {
 }
 
 func (msg FinalizeMsg) String() string {
-	return "Finalize"
+	return "Finalize" // TODO: Issue #3
 }
 
 func (msg FinalizeMsg) ValidateBasic() sdk.Error {
@@ -226,7 +222,7 @@ func (tx BaseTx) GetFeePayer() crypto.Address       { return tx.Signatures[0].Pu
 func (tx BaseTx) GetSignatures() []sdk.StdSignature { return tx.Signatures }
 
 func RegisterAmino(cdc *amino.Codec) {
-	// TODO include option to always include prefix bytes.
+	// TODO include option to always include prefix bytes
 	cdc.RegisterConcrete(SpendMsg{}, "plasma-mvp-sidechain/SpendMsg", nil)
 	cdc.RegisterConcrete(BaseTx{}, "plasma-mvp-sidechain/BaseTx", nil)
 }

--- a/types/utils.go
+++ b/types/utils.go
@@ -1,11 +1,10 @@
 package types
 
 import (
-crypto "github.com/tendermint/go-crypto"
-"math/big"
+	crypto "github.com/tendermint/go-crypto"
+	"math/big"
 )
 
 func ZeroAddress(addr crypto.Address) bool {
 	return new(big.Int).SetBytes(addr.Bytes()).Sign() == 0
 }
-

--- a/types/utils.go
+++ b/types/utils.go
@@ -1,0 +1,11 @@
+package types
+
+import (
+crypto "github.com/tendermint/go-crypto"
+"math/big"
+)
+
+func ZeroAddress(addr crypto.Address) bool {
+	return new(big.Int).SetBytes(addr.Bytes()).Sign() == 0
+}
+

--- a/types/utxo.go
+++ b/types/utxo.go
@@ -1,0 +1,87 @@
+package utxo //might need to be adjusted
+
+import (
+	crypto "github.com/tendermint/go-crypto"
+	"errors"
+)
+
+// UTXO is a standard unspent transaction output
+// Has pubkey for authentication
+type UTXO interface {
+	// Get and Set for public key of utxo
+	GetPubKey() crypto.PubKey
+	SetPubKey(crypto.PubKey) error // errors if already set
+
+	//Get and Set denomination of the utxo. Is uint64 appropriate type?
+	GetDenom() uint64
+	SetDenom(uint64) error //errors if already set
+
+	Get(key interface{}) (value interface{}, err error)
+	Set(key interface{}, value interface{}) error
+	
+	//TODO: ADD SUPPORT FOR DIFFERENT COINS
+
+}
+
+// UTXOMapper interface which stores and retrieves utxos from stores
+// retrieved from the context
+// Can create and destory utxo 
+// Consider Changing?
+type UTXOMapper interface {
+	GetUXTO(ctx Context, pubkey crypto.PubKey) UTXO
+	CreateUTXO(ctx Context, utxo UTXO)
+	DestroyUTXO(ctx Context, utxo UTXO)
+}
+
+// Consider moving BaseUTXO and AppUTXO to another file. Are they necessary?
+// Currently being used a prototype
+type BaseUTXO struct {
+	PubKey crypto.PubKey
+	Denom uint64
+}
+
+func NewBaseUTXO(pubkey crypto.PubKey) BaseUTXO {
+	return BaseUTXO {
+		PubKey: pubkey,
+	}
+}
+
+// Implements UTXO 
+// Not sure what this is supposed to achieve. Modeled from baseaccount
+func (utxo *BaseUTXO) Get(key interface{}) (value interface{}, err error) {
+	panic("not implemented yet")
+}
+
+// Implements UTXO 
+// Not sure what this is supposed to achieve. Modeled from baseaccount
+func (utxo *BaseUTXO) Set(key interface{}, value interface{}) error {
+	panic("not implemented yet")
+}
+
+//Implements UTXO 
+func (utxo *BaseUTXO) GetPubKey() crypto.PubKey {
+	return utxo.PubKey
+}
+
+//Implements UTXO
+func (utxo *BaseUTXO) SetPubKey(pubkey crypto.PubKey) error{
+	if utxo.PubKey != nil {
+		return errors.New("cannot override BaseUTXO Public Key")
+	}
+	utxo.PubKey = pubkey
+	return nil
+}
+
+//Implements UTXO
+func (utxo *BaseUTXO) GetDenom() uint64 {
+	return utxo.Denom
+}
+
+//Implements UTXO
+func (utxo *BaseUTXO) SetDenom(denom uint64) error {
+	if utxo.Denom != 0 {
+		return errors.New("Cannot override BaseUTXO denomination")
+	}
+	utxo.Denom = denom
+	return nil
+}

--- a/types/utxo.go
+++ b/types/utxo.go
@@ -1,17 +1,15 @@
-package utxo //might need to be adjusted
+package types //might need to be adjusted
 
 import (
 	crypto "github.com/tendermint/go-crypto"
 	"errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 )
 
 // UTXO is a standard unspent transaction output
 // Has pubkey for authentication
 type UTXO interface {
-	// Get and Set for public key of utxo
-	GetPubKey() crypto.PubKey
-	SetPubKey(crypto.PubKey) error // errors if already set
-
 	GetAddress() crypto.Address
 	SetAddress(crypto.Address) error // errors if already set
 
@@ -31,60 +29,44 @@ type UTXO interface {
 // Can create and destory utxo 
 // Consider Changing?
 type UTXOMapper interface {
-	GetUXTO(ctx Context, addr crypto.Address) UTXO
-	CreateUTXO(ctx Context, utxo UTXO)
-	DestroyUTXO(ctx Context, utxo UTXO)
+	GetUXTO(ctx sdk.Context, addr crypto.Address) UTXO
+	CreateUTXO(ctx sdk.Context, utxo UTXO)
+	DestroyUTXO(ctx sdk.Context, utxo UTXO)
 }
 
 // Consider moving BaseUTXO and AppUTXO to another file. Are they necessary?
 // Currently being used a prototype
 type BaseUTXO struct {
-	PubKey crypto.PubKey
 	Address crypto.Address
 	Denom uint64
 }
 
-func NewBaseUTXO(pubkey crypto.PubKey, addr crypto.Address, denom uint64) BaseUTXO {
+func NewBaseUTXO(addr crypto.Address, denom uint64) BaseUTXO {
 	return BaseUTXO {
-		PubKey: pubkey,
 		Address: addr,
-		Denom: uint64,
+		Denom: denom,
 	}
 }
 
 // Implements UTXO 
 // Not sure what this is supposed to achieve. Modeled from baseaccount
-func (utxo *BaseUTXO) Get(key interface{}) (value interface{}, err error) {
+func (utxo BaseUTXO) Get(key interface{}) (value interface{}, err error) {
 	panic("not implemented yet")
 }
 
 // Implements UTXO 
 // Not sure what this is supposed to achieve. Modeled from baseaccount
-func (utxo *BaseUTXO) Set(key interface{}, value interface{}) error {
+func (utxo BaseUTXO) Set(key interface{}, value interface{}) error {
 	panic("not implemented yet")
 }
 
 //Implements UTXO 
-func (utxo *BaseUTXO) GetPubKey() crypto.PubKey {
-	return utxo.PubKey
-}
-
-//Implements UTXO
-func (utxo *BaseUTXO) SetPubKey(pubkey crypto.PubKey) error{
-	if utxo.PubKey != nil {
-		return errors.New("cannot override BaseUTXO Public Key")
-	}
-	utxo.PubKey = pubkey
-	return nil
-}
-
-//Implements UTXO 
-func (utxo *BaseUTXO) GetAddress() crypto.Address {
+func (utxo BaseUTXO) GetAddress() crypto.Address {
 	return utxo.Address
 }
 
 //Implements UTXO
-func (utxo *BaseUTXO) SetAddress(addr crypto.Address) error{
+func (utxo BaseUTXO) SetAddress(addr crypto.Address) error{
 	if utxo.Address != nil {
 		return errors.New("cannot override BaseUTXO Address")
 	}
@@ -93,12 +75,12 @@ func (utxo *BaseUTXO) SetAddress(addr crypto.Address) error{
 }
 
 //Implements UTXO
-func (utxo *BaseUTXO) GetDenom() uint64 {
+func (utxo BaseUTXO) GetDenom() uint64 {
 	return utxo.Denom
 }
 
 //Implements UTXO
-func (utxo *BaseUTXO) SetDenom(denom uint64) error {
+func (utxo BaseUTXO) SetDenom(denom uint64) error {
 	if utxo.Denom != 0 {
 		return errors.New("Cannot override BaseUTXO denomination")
 	}

--- a/types/utxo.go
+++ b/types/utxo.go
@@ -12,6 +12,9 @@ type UTXO interface {
 	GetPubKey() crypto.PubKey
 	SetPubKey(crypto.PubKey) error // errors if already set
 
+	GetAddress() crypto.Address
+	SetAddress(crypto.Address) error // errors if already set
+
 	//Get and Set denomination of the utxo. Is uint64 appropriate type?
 	GetDenom() uint64
 	SetDenom(uint64) error //errors if already set
@@ -28,7 +31,7 @@ type UTXO interface {
 // Can create and destory utxo 
 // Consider Changing?
 type UTXOMapper interface {
-	GetUXTO(ctx Context, pubkey crypto.PubKey) UTXO
+	GetUXTO(ctx Context, addr crypto.Address) UTXO
 	CreateUTXO(ctx Context, utxo UTXO)
 	DestroyUTXO(ctx Context, utxo UTXO)
 }
@@ -37,12 +40,15 @@ type UTXOMapper interface {
 // Currently being used a prototype
 type BaseUTXO struct {
 	PubKey crypto.PubKey
+	Address crypto.Address
 	Denom uint64
 }
 
-func NewBaseUTXO(pubkey crypto.PubKey) BaseUTXO {
+func NewBaseUTXO(pubkey crypto.PubKey, addr crypto.Address, denom uint64) BaseUTXO {
 	return BaseUTXO {
 		PubKey: pubkey,
+		Address: addr,
+		Denom: uint64,
 	}
 }
 
@@ -69,6 +75,20 @@ func (utxo *BaseUTXO) SetPubKey(pubkey crypto.PubKey) error{
 		return errors.New("cannot override BaseUTXO Public Key")
 	}
 	utxo.PubKey = pubkey
+	return nil
+}
+
+//Implements UTXO 
+func (utxo *BaseUTXO) GetAddress() crypto.Address {
+	return utxo.Address
+}
+
+//Implements UTXO
+func (utxo *BaseUTXO) SetAddress(addr crypto.Address) error{
+	if utxo.Address != nil {
+		return errors.New("cannot override BaseUTXO Address")
+	}
+	utxo.Address = addr
 	return nil
 }
 

--- a/types/utxo.go
+++ b/types/utxo.go
@@ -132,21 +132,22 @@ func (utxo BaseUTXO) SetConfirmSigs(sigs []sdk.StdSignature) error {
 
 // Holds a list of UTXO's
 // All utxo's have same address, but possibly different denominations 
+// UtxoList needs to be public for go amino encoding to work
 type BaseUTXOHolder struct {
-	utxoList []UTXO
+	UtxoList []UTXO
 }
 
 // Creates a new UTXOHolder 
 // utxoList is a slice initialized with length 1 and capacity 10
 func NewUTXOHolder() BaseUTXOHolder {
 	return BaseUTXOHolder {
-		utxoList: 	make([]UTXO, 1, 10),
+		UtxoList: 	make([]UTXO, 1, 10),
 	}
 }
 
 // Gets the utxo from the utxoList
 func (uh BaseUTXOHolder) GetUTXO(position [3]uint) (UTXO, int) {
-	for index, elem := range uh.utxoList {
+	for index, elem := range uh.UtxoList {
 		if elem.GetPosition() == position {
 			return elem, index
 		}
@@ -156,10 +157,10 @@ func (uh BaseUTXOHolder) GetUTXO(position [3]uint) (UTXO, int) {
 
 // Delete utxo from utxoList
 func (uh BaseUTXOHolder) DeleteUTXO(utxo UTXO) error {
-	for index, elem := range uh.utxoList {
+	for index, elem := range uh.UtxoList {
 		// If two utxo's are identical in the list it will delete the first one
 		if elem.GetPosition() == utxo.GetPosition() {
-			uh.utxoList = append(uh.utxoList[:index], uh.utxoList[index + 1:]...)
+			uh.UtxoList = append(uh.UtxoList[:index], uh.UtxoList[index + 1:]...)
 			return nil
 		}
 	}
@@ -168,12 +169,12 @@ func (uh BaseUTXOHolder) DeleteUTXO(utxo UTXO) error {
 
 // Apends a utxo to the utxoList
 func (uh BaseUTXOHolder) AddUTXO(utxo UTXO) error {
-	uh.utxoList = append(uh.utxoList, utxo)
+	uh.UtxoList = append(uh.UtxoList, utxo)
 	return nil
 }
 
 func (uh BaseUTXOHolder) FinalizeUTXO(denom uint64, sigs []sdk.StdSignature, position [3]uint) error {
-	for _, elem := range uh.utxoList {
+	for _, elem := range uh.UtxoList {
 		// Find first unfinalized UTXO with same position and finalize with position
 		if elem.GetDenom() == denom && elem.GetPosition()[0] == 0 {
 			elem.SetPosition(position[0], position[1], position[2])
@@ -185,5 +186,5 @@ func (uh BaseUTXOHolder) FinalizeUTXO(denom uint64, sigs []sdk.StdSignature, pos
 }
 
 func (uh BaseUTXOHolder) GetLength() int {
-	return len(uh.utxoList)
+	return len(uh.UtxoList)
 }

--- a/types/utxo.go
+++ b/types/utxo.go
@@ -8,9 +8,7 @@ import (
 // UTXO is a standard unspent transaction output
 // Has pubkey for authentication
 type UTXO interface {
-	// Decided to use address instead of public keys
-	// since each utxo newly created will be created from an
-	// Ethereum address
+	// Address to which UTXO's are sent
 	GetAddress() crypto.Address
 	SetAddress(crypto.Address) error // errors if already set
 
@@ -39,8 +37,6 @@ type UTXOHolder interface {
 	GetLength() int
 }
 
-// Consider moving BaseUTXO and AppUTXO to another file. Are they necessary?
-// Currently being used a prototype
 // BaseUTXO must have all confirm signatures in order of most recent up until the signatures of the original depsosits.
 type BaseUTXO struct {
 	Address     crypto.Address
@@ -127,7 +123,7 @@ func (utxo BaseUTXO) SetConfirmSigs(sigs [2]crypto.Signature) error {
 }
 
 func emptySignatures() [2]crypto.Signature {
-	return [2]crypto.Signature{crypto.Signature{}, crypto.Signature{}}
+	return [2]crypto.Signature{crypto.SignatureSecp256k1{}, crypto.SignatureSecp256k1{}}
 }
 
 //----------------------------------------
@@ -135,27 +131,26 @@ func emptySignatures() [2]crypto.Signature {
 
 // Holds a list of UTXO's
 // All utxo's have same address, but possibly different denominations
-// UtxoList needs to be public for go amino encoding to work
 type BaseUTXOHolder struct {
 	UtxoList []UTXO
 }
 
 // Creates a new UTXOHolder
-// utxoList is a slice initialized with length 1 and capacity 10
+// UtxoList is a slice initialized with length 1 and capacity 10
 func NewUTXOHolder() BaseUTXOHolder {
 	return BaseUTXOHolder{
 		UtxoList: make([]UTXO, 1, 10),
 	}
 }
 
-// Gets the utxo from the utxoList
+// Gets the utxo from the UtxoList
 func (uh BaseUTXOHolder) GetUTXO(position [3]uint) (UTXO, int) {
 	for index, elem := range uh.UtxoList {
 		if elem.GetPosition() == position {
 			return elem, index
 		}
 	}
-	return BaseUTXO{}, 0 //utxo is not in the list
+	return BaseUTXO{}, 0 // utxo is not in the list
 }
 
 // Delete utxo from utxoList


### PR DESCRIPTION
Most of what I've done is the base implementation. It is modeled closely to Basecoin, but changed to utxo rather than being account based. It is not complete nor fully functional. I think this pr should be brought into a develop branch rather than master since it needs a lot of work, but if everyone is fine with the design choices then it would be fine to bring into master. I thought I'd do a pr writeup in case others want to develop of this. 

`app.go:`
Where the ChildChain is constructed. Currently uses go amino encoding, but that will need to be changed to rlp in the future. 

`app_test.go`
Test file for app. Currently only contains a single test which checks if a utxo trying to spent exists or not.

`mapper.go`
Contains UTXOMapper struct which is responsible for accessing the KVStore that should map an address to encoded bytes. Main UTXOMapper methods include: GetUTXO, CreateUTXO, and DestroyUTXO. Modeled similar to basecoin's AccountMapper. One different design choice is that I am trying to use UTXOHolder to store utxo's for an account and then encode the holder. Essentially the utxomapper maps address to encoded utxoholders. Everything works alright except one important issue is the slice within the utxoholder struct is not being included in the encoding and therefore the utxo's are not being saved. I chose to use a utxoholder since the mapping is using the address and the users address can have multiple utxo's sent to it. This file also contains UTXOKeeper which simply handles the logic of calling the UTXOMapper's functions. 

`utxo.go`
Contains UTXO interface, UTXOHolder interface, and BaseUTXO which is the base implementation of the UTXO interface. It also contains BaseUTXOHolder which is the base implementation of the UTXOHolder interface.

`handler.go`
Base implementation of a handler for our messages. handleSpendMsg and handleDepositMsg need to actually be implemented. Mostly just a partially working framework right now

`tx.go`
 Contains SpendMsg, DepositMsg, and BaseTx. Mostly just base implementation right now. We should highly consider a different design for the Messages than the current implementation. Currently uses go-amino encoding so I could run tests. It is important to keep in mind that how we design the structs will correspond to how they are decoded on the rootContract as they structures are what will be included in a txHash. The do need to include a reference to the original input owner and the value of the original inputs so the utxokeeper can function correctly. I think we should consider adding input and output structs inside of spendmsg and possibly depositMsg. 

If this gets merged, please feel free to delete any unnecessary comments/fix style. I purposely did excessive comments so when everyone reviewed the code it might be easier to understand. 
 
Known Issues/WIP:
- Needs RLP Encoding
- Needs AnteHandler
- UTXOHandler is not being encoded correctly
- Probably will need to build a custom store to use as a merkle tree instead of the current avl tree (or adjust root contract)
- Will need to change hash function to sha3 (or adjust rootcontract)
