### PR TITLE
Legeng/utxomapper keys

### DIFF
--- a/auth/ante.go
+++ b/auth/ante.go
@@ -57,8 +57,6 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 
 		res = processSig(addr1, sigs[0], signBytes)
 
-		// res := processSig(ctx, utxoMapper, position1, addr1, sigs[0], signBytes)
-
 		if !res.IsOK() {
 			return ctx, res, true
 		}
@@ -83,8 +81,6 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 			}
 
 			res = processSig(addr2, sigs[1], signBytes)
-
-			// res = processSig(ctx, utxoMapper, position2, addr2, sigs[1], signBytes)
 
 			if !res.IsOK() {
 				return ctx, res, true
@@ -117,17 +113,6 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 func processSig(
 	addr common.Address, sig types.Signature, signBytes []byte) (
 	res sdk.Result) {
-
-	// Verify utxo exists
-	utxo := um.GetUTXO(ctx, addr, position)
-	if utxo == nil {
-		return sdk.ErrUnknownRequest("UTXO trying to be spent, does not exist").Result()
-	}
-
-	// Verify that utxo owner equals input address in the transaction
-	if !reflect.DeepEqual(utxo.GetAddress().Bytes(), addr.Bytes()) {
-		return sdk.ErrUnauthorized("signer does not match utxo owner").Result()
-	}
 
 	hash := ethcrypto.Keccak256(signBytes)
 	pubKey1, err1 := ethcrypto.SigToPub(hash, sig.Bytes())
@@ -171,7 +156,7 @@ func processConfirmSig(
 // Checks that utxo at the position specified exists, matches the address in the SpendMsg
 // and returns the denomination associated with the utxo
 func checkUTXO(ctx sdk.Context, mapper types.UTXOMapper, position types.Position, addr common.Address) (indenom uint64, res sdk.Result) {
-	utxo := mapper.GetUTXO(ctx, position)
+	utxo := mapper.GetUTXO(ctx, addr, position)
 	if utxo == nil {
 		return 0, sdk.ErrUnknownRequest("UTXO trying to be spend, does not exist").Result()
 	}

--- a/auth/handler.go
+++ b/auth/handler.go
@@ -25,15 +25,17 @@ func NewHandler(uk db.UTXOKeeper, txIndex *uint16) sdk.Handler {
 func handleSpendMsg(ctx sdk.Context, uk db.UTXOKeeper, msg types.SpendMsg, txIndex *uint16) sdk.Result {
 
 	position1 := types.Position{msg.Blknum1, msg.Txindex1, msg.Oindex1, msg.DepositNum1}
-	utxo1 := uk.UM.GetUTXO(ctx, position1)
+	inputAddr1 := msg.Owner1
+	utxo1 := uk.UM.GetUTXO(ctx, inputAddr1, position1)
+	uk.SpendUTXO(ctx, inputAddr1, position1)
+
 	var position2 types.Position
 	var utxo2 types.UTXO
-	uk.SpendUTXO(ctx, position1)
-
-	if !utils.ZeroAddress(msg.Owner2) {
+	inputAddr2 := msg.Owner2
+	if !utils.ZeroAddress(inputAddr2) {
 		position2 = types.Position{msg.Blknum2, msg.Txindex2, msg.Oindex2, msg.DepositNum2}
-		utxo2 = uk.UM.GetUTXO(ctx, position2)
-		uk.SpendUTXO(ctx, position2)
+		utxo2 = uk.UM.GetUTXO(ctx, inputAddr2, position2)
+		uk.SpendUTXO(ctx, inputAddr2, position2)
 	}
 
 	oldUTXOs := [2]types.UTXO{utxo1, utxo2}

--- a/auth/handler_test.go
+++ b/auth/handler_test.go
@@ -46,8 +46,8 @@ func TestHandleSpendMessage(t *testing.T) {
 	utxo2 := NewUTXO(privA, privC, positionC)
 	mapper.AddUTXO(ctx, utxo1)
 	mapper.AddUTXO(ctx, utxo2)
-	utxo1 = mapper.GetUTXO(ctx, positionB)
-	utxo2 = mapper.GetUTXO(ctx, positionC)
+	utxo1 = mapper.GetUTXO(ctx, utils.PrivKeyToAddress(privB), positionB)
+	utxo2 = mapper.GetUTXO(ctx, utils.PrivKeyToAddress(privC), positionC)
 	assert.NotNil(t, utxo1)
 	assert.NotNil(t, utxo2)
 
@@ -82,18 +82,18 @@ func TestHandleSpendMessage(t *testing.T) {
 	assert.Equal(t, uint16(1), *txIndex) // txIndex incremented
 
 	//Check that inputs were deleted
-	utxo := mapper.GetUTXO(ctx, positionB)
+	utxo := mapper.GetUTXO(ctx, utils.PrivKeyToAddress(privB), positionB)
 	assert.Nil(t, utxo)
-	utxo = mapper.GetUTXO(ctx, positionC)
+	utxo = mapper.GetUTXO(ctx, utils.PrivKeyToAddress(privC), positionC)
 	assert.Nil(t, utxo)
 
 	// Check to see if outputs were added
 	assert.Equal(t, int64(2), ctx.BlockHeight())
 	positionD := types.Position{2, 0, 0, 0}
 	positionE := types.Position{2, 0, 1, 0}
-	utxo1 = mapper.GetUTXO(ctx, positionD)
+	utxo1 = mapper.GetUTXO(ctx, newownerA, positionD)
 	assert.NotNil(t, utxo1)
-	utxo2 = mapper.GetUTXO(ctx, positionE)
+	utxo2 = mapper.GetUTXO(ctx, newownerB, positionE)
 	assert.NotNil(t, utxo2)
 
 	// Check that outputs are valid
@@ -123,7 +123,7 @@ func TestOneInput(t *testing.T) {
 	positionB := types.Position{1000, 0, 0, 0}
 	utxo1 := NewUTXO(privA, privB, positionB)
 	mapper.AddUTXO(ctx, utxo1)
-	utxo1 = mapper.GetUTXO(ctx, positionB)
+	utxo1 = mapper.GetUTXO(ctx, utils.PrivKeyToAddress(privB), positionB)
 	assert.NotNil(t, utxo1)
 
 	newownerA := utils.GenerateAddress()
@@ -157,16 +157,16 @@ func TestOneInput(t *testing.T) {
 	assert.Equal(t, uint16(1), *txIndex) // txIndex incremented
 
 	//Check that inputs were deleted
-	utxo := mapper.GetUTXO(ctx, positionB)
+	utxo := mapper.GetUTXO(ctx, utils.PrivKeyToAddress(privB), positionB)
 	assert.Nil(t, utxo)
 
 	// Check to see if outputs were added
 	assert.Equal(t, int64(2), ctx.BlockHeight())
 	positionD := types.Position{2, 0, 0, 0}
 	positionE := types.Position{2, 0, 1, 0}
-	utxo1 = mapper.GetUTXO(ctx, positionD)
+	utxo1 = mapper.GetUTXO(ctx, newownerA, positionD)
 	assert.NotNil(t, utxo1)
-	utxo2 := mapper.GetUTXO(ctx, positionE)
+	utxo2 := mapper.GetUTXO(ctx, newownerB, positionE)
 	assert.NotNil(t, utxo2)
 
 	// Check that outputs are valid

--- a/db/keeper.go
+++ b/db/keeper.go
@@ -17,8 +17,8 @@ func NewUTXOKeeper(um types.UTXOMapper) UTXOKeeper {
 
 // Delete's utxo from utxo store
 // AnteHandler should have already checked existence of the utxo
-func (uk UTXOKeeper) SpendUTXO(ctx sdk.Context, position types.Position) {
-	uk.UM.DeleteUTXO(ctx, position)
+func (uk UTXOKeeper) SpendUTXO(ctx sdk.Context, addr common.Address, position types.Position) {
+	uk.UM.DeleteUTXO(ctx, addr, position)
 }
 
 // Creates a new utxo and adds it to the utxo store

--- a/db/mapper.go
+++ b/db/mapper.go
@@ -29,10 +29,10 @@ func NewUTXOMapper(contextKey sdk.StoreKey, cdc *amino.Codec) types.UTXOMapper {
 
 // Returns the UTXO corresponding to the go amino encoded Position struct
 // Returns nil if no UTXO exists at that position
-func (um utxoMapper) GetUTXO(ctx sdk.Context, address common.Address, position types.Position) types.UTXO {
+func (um utxoMapper) GetUTXO(ctx sdk.Context, addr common.Address, position types.Position) types.UTXO {
 	store := ctx.KVStore(um.contextKey)
 	pos := um.encodePosition(position)
-	pos = append(address.Bytes(), pos...)
+	pos = append(addr.Bytes(), pos...)
 	bz := store.Get(pos)
 
 	if bz == nil {
@@ -57,10 +57,10 @@ func (um utxoMapper) AddUTXO(ctx sdk.Context, utxo types.UTXO) {
 }
 
 // Deletes UTXO corresponding to the position from mapping
-func (um utxoMapper) DeleteUTXO(ctx sdk.Context, address common.Address, position types.Position) {
+func (um utxoMapper) DeleteUTXO(ctx sdk.Context, addr common.Address, position types.Position) {
 	store := ctx.KVStore(um.contextKey)
 	pos := um.encodePosition(position)
-	pos = append(address.Bytes(), pos...)
+	pos = append(addr.Bytes(), pos...)
 	store.Delete(pos)
 }
 

--- a/db/mapper.go
+++ b/db/mapper.go
@@ -31,7 +31,7 @@ func NewUTXOMapper(contextKey sdk.StoreKey, cdc *amino.Codec) types.UTXOMapper {
 // Returns nil if no UTXO exists at that position
 func (um utxoMapper) GetUTXO(ctx sdk.Context, addr common.Address, position types.Position) types.UTXO {
 	store := ctx.KVStore(um.contextKey)
-	key := um.getKeyFromAddressAndPosition(addr, position)
+	key := um.constructKey(addr, position)
 
 	bz := store.Get(key)
 
@@ -45,7 +45,7 @@ func (um utxoMapper) GetUTXO(ctx sdk.Context, addr common.Address, position type
 
 // Returns all the UTXOs owned by an address.
 // Returns empty slice if no UTXO exists for the address.
-func (um utxoMapper) GetAllUTXOsForAddress(ctx sdk.Context, addr common.Address) []types.UTXO {
+func (um utxoMapper) GetUTXOsForAddress(ctx sdk.Context, addr common.Address) []types.UTXO {
 	store := ctx.KVStore(um.contextKey)
 	iterator := sdk.KVStorePrefixIterator(store, addr.Bytes())
 	utxos := make([]types.UTXO, 0)
@@ -65,7 +65,7 @@ func (um utxoMapper) AddUTXO(ctx sdk.Context, utxo types.UTXO) {
 	address := utxo.GetAddress()
 	store := ctx.KVStore(um.contextKey)
 
-	key := um.getKeyFromAddressAndPosition(address, position)
+	key := um.constructKey(address, position)
 	bz := um.encodeUTXO(utxo)
 	store.Set(key, bz)
 }
@@ -73,12 +73,12 @@ func (um utxoMapper) AddUTXO(ctx sdk.Context, utxo types.UTXO) {
 // Deletes UTXO corresponding to address + position from mapping
 func (um utxoMapper) DeleteUTXO(ctx sdk.Context, addr common.Address, position types.Position) {
 	store := ctx.KVStore(um.contextKey)
-	key := um.getKeyFromAddressAndPosition(addr, position)
+	key := um.constructKey(addr, position)
 	store.Delete(key)
 }
 
 // (<address> + <encoded position>) forms the unique key that maps to an UTXO.
-func (um utxoMapper) getKeyFromAddressAndPosition(address common.Address, position types.Position) []byte {
+func (um utxoMapper) constructKey(address common.Address, position types.Position) []byte {
 	pos := um.encodePosition(position)
 	key := append(address.Bytes(), pos...)
 	return key

--- a/db/mapper.go
+++ b/db/mapper.go
@@ -27,13 +27,13 @@ func NewUTXOMapper(contextKey sdk.StoreKey, cdc *amino.Codec) types.UTXOMapper {
 
 }
 
-// Returns the UTXO corresponding to the go amino encoded Position struct
+// Returns the UTXO corresponding to the address + go amino encoded Position struct
 // Returns nil if no UTXO exists at that position
 func (um utxoMapper) GetUTXO(ctx sdk.Context, addr common.Address, position types.Position) types.UTXO {
 	store := ctx.KVStore(um.contextKey)
-	pos := um.encodePosition(position)
-	pos = append(addr.Bytes(), pos...)
-	bz := store.Get(pos)
+	key := um.getKeyFromAddressAndPosition(addr, position)
+
+	bz := store.Get(key)
 
 	if bz == nil {
 		return nil
@@ -43,25 +43,45 @@ func (um utxoMapper) GetUTXO(ctx sdk.Context, addr common.Address, position type
 	return utxo
 }
 
+// Returns all the UTXOs owned by an address.
+// Returns empty slice if no UTXO exists for the address.
+func (um utxoMapper) GetAllUTXOsForAddress(ctx sdk.Context, addr common.Address) []types.UTXO {
+	store := ctx.KVStore(um.contextKey)
+	iterator := sdk.KVStorePrefixIterator(store, addr.Bytes())
+	utxos := make([]types.UTXO, 0)
+
+	for ; iterator.Valid(); iterator.Next() {
+		utxo := um.decodeUTXO(iterator.Value())
+		utxos = append(utxos, utxo)
+	}
+	iterator.Close()
+
+	return utxos
+}
+
 // Adds the UTXO to the mapper
 func (um utxoMapper) AddUTXO(ctx sdk.Context, utxo types.UTXO) {
 	position := utxo.GetPosition()
-	pos := um.encodePosition(position)
-
-	addr := utxo.GetAddress().Bytes()
-	pos = append(addr, pos...)
-
+	address := utxo.GetAddress()
 	store := ctx.KVStore(um.contextKey)
+
+	key := um.getKeyFromAddressAndPosition(address, position)
 	bz := um.encodeUTXO(utxo)
-	store.Set(pos, bz)
+	store.Set(key, bz)
 }
 
-// Deletes UTXO corresponding to the position from mapping
+// Deletes UTXO corresponding to address + position from mapping
 func (um utxoMapper) DeleteUTXO(ctx sdk.Context, addr common.Address, position types.Position) {
 	store := ctx.KVStore(um.contextKey)
+	key := um.getKeyFromAddressAndPosition(addr, position)
+	store.Delete(key)
+}
+
+// (<address> + <encoded position>) forms the unique key that maps to an UTXO.
+func (um utxoMapper) getKeyFromAddressAndPosition(address common.Address, position types.Position) []byte {
 	pos := um.encodePosition(position)
-	pos = append(addr.Bytes(), pos...)
-	store.Delete(pos)
+	key := append(address.Bytes(), pos...)
+	return key
 }
 
 func (um utxoMapper) encodeUTXO(utxo types.UTXO) []byte {

--- a/db/mapper_test.go
+++ b/db/mapper_test.go
@@ -172,3 +172,55 @@ func TestMultiUTXOAddDeleteDifferentBlock(t *testing.T) {
 	}
 
 }
+
+/*
+	Test getting all UTXOs for an Address.
+*/
+
+func TestGetAllUTXOsForAddress(t *testing.T) {
+	ms, capKey := SetupMultiStore()
+
+	ctx := sdk.NewContext(ms, abci.Header{}, false, nil, log.NewNopLogger())
+	mapper := NewUTXOMapper(capKey, MakeCodec())
+
+	privA, _ := ethcrypto.GenerateKey()
+	addrA := utils.PrivKeyToAddress(privA)
+
+	privB, _ := ethcrypto.GenerateKey()
+	addrB := utils.PrivKeyToAddress(privB)
+
+	privC, _ := ethcrypto.GenerateKey()
+	addrC := utils.PrivKeyToAddress(privC)
+
+	positionB1 := types.Position{1000, 0, 0, 0}
+	positionB2 := types.Position{1001, 1, 0, 0}
+	positionB3 := types.Position{1002, 2, 1, 0}
+	confirmAddr := [2]common.Address{addrA, addrA}
+
+	utxo1 := types.NewBaseUTXO(addrB, confirmAddr, 100, positionB1)
+	utxo2 := types.NewBaseUTXO(addrB, confirmAddr, 200, positionB2)
+	utxo3 := types.NewBaseUTXO(addrB, confirmAddr, 300, positionB3)
+
+	mapper.AddUTXO(ctx, utxo1)
+	mapper.AddUTXO(ctx, utxo2)
+	mapper.AddUTXO(ctx, utxo3)
+
+	utxosForAddressB := mapper.GetAllUTXOsForAddress(ctx, addrB)
+	assert.NotNil(t, utxosForAddressB)
+	assert.Equal(t, 3, len(utxosForAddressB))
+	assert.Equal(t, utxo1, utxosForAddressB[0])
+	assert.Equal(t, utxo2, utxosForAddressB[1])
+	assert.Equal(t, utxo3, utxosForAddressB[2])
+
+	positionC1 := types.Position{1002, 3, 0, 0}
+	utxo4 := types.NewBaseUTXO(addrC, confirmAddr, 300, positionC1)
+	mapper.AddUTXO(ctx, utxo4)
+	utxosForAddressC := mapper.GetAllUTXOsForAddress(ctx, addrC)
+	assert.NotNil(t, utxosForAddressC)
+	assert.Equal(t, 1, len(utxosForAddressC))
+	assert.Equal(t, utxo4, utxosForAddressC[0])
+
+	// check returns empty slice if no UTXOs exist for address
+	utxosForAddressA := mapper.GetAllUTXOsForAddress(ctx, addrA)
+	assert.Empty(t, utxosForAddressA)
+}

--- a/db/mapper_test.go
+++ b/db/mapper_test.go
@@ -177,7 +177,7 @@ func TestMultiUTXOAddDeleteDifferentBlock(t *testing.T) {
 	Test getting all UTXOs for an Address.
 */
 
-func TestGetAllUTXOsForAddress(t *testing.T) {
+func TestGetUTXOsForAddress(t *testing.T) {
 	ms, capKey := SetupMultiStore()
 
 	ctx := sdk.NewContext(ms, abci.Header{}, false, nil, log.NewNopLogger())
@@ -205,7 +205,7 @@ func TestGetAllUTXOsForAddress(t *testing.T) {
 	mapper.AddUTXO(ctx, utxo2)
 	mapper.AddUTXO(ctx, utxo3)
 
-	utxosForAddressB := mapper.GetAllUTXOsForAddress(ctx, addrB)
+	utxosForAddressB := mapper.GetUTXOsForAddress(ctx, addrB)
 	assert.NotNil(t, utxosForAddressB)
 	assert.Equal(t, 3, len(utxosForAddressB))
 	assert.Equal(t, utxo1, utxosForAddressB[0])
@@ -215,12 +215,12 @@ func TestGetAllUTXOsForAddress(t *testing.T) {
 	positionC1 := types.Position{1002, 3, 0, 0}
 	utxo4 := types.NewBaseUTXO(addrC, confirmAddr, 300, positionC1)
 	mapper.AddUTXO(ctx, utxo4)
-	utxosForAddressC := mapper.GetAllUTXOsForAddress(ctx, addrC)
+	utxosForAddressC := mapper.GetUTXOsForAddress(ctx, addrC)
 	assert.NotNil(t, utxosForAddressC)
 	assert.Equal(t, 1, len(utxosForAddressC))
 	assert.Equal(t, utxo4, utxosForAddressC[0])
 
 	// check returns empty slice if no UTXOs exist for address
-	utxosForAddressA := mapper.GetAllUTXOsForAddress(ctx, addrA)
+	utxosForAddressA := mapper.GetUTXOsForAddress(ctx, addrA)
 	assert.Empty(t, utxosForAddressA)
 }

--- a/db/mapper_test.go
+++ b/db/mapper_test.go
@@ -43,11 +43,11 @@ func TestUTXOGetAddDelete(t *testing.T) {
 	assert.EqualValues(t, positionB, utxo.GetPosition())
 
 	mapper.AddUTXO(ctx, utxo)
-	utxo = mapper.GetUTXO(ctx, positionB)
+	utxo = mapper.GetUTXO(ctx, addrB, positionB)
 	assert.NotNil(t, utxo)
 
-	mapper.DeleteUTXO(ctx, positionB)
-	utxo = mapper.GetUTXO(ctx, positionB)
+	mapper.DeleteUTXO(ctx, addrB, positionB)
+	utxo = mapper.GetUTXO(ctx, addrB, positionB)
 	assert.Nil(t, utxo)
 }
 
@@ -77,16 +77,16 @@ func TestMultiUTXOAddDeleteSameBlock(t *testing.T) {
 		positionB := types.Position{1000, uint16(i), 0, 0}
 		utxo := types.NewBaseUTXO(addrB, confirmAddr, 100, positionB)
 		mapper.AddUTXO(ctx, utxo)
-		utxo = mapper.GetUTXO(ctx, positionB)
+		utxo = mapper.GetUTXO(ctx, addrB, positionB)
 		assert.NotNil(t, utxo)
 	}
 
 	for i := 0; i < 10; i++ {
 		position := types.Position{1000, uint16(i), 0, 0}
-		utxo := mapper.GetUTXO(ctx, position)
+		utxo := mapper.GetUTXO(ctx, addrB, position)
 		assert.NotNil(t, utxo)
-		mapper.DeleteUTXO(ctx, position)
-		utxo = mapper.GetUTXO(ctx, position)
+		mapper.DeleteUTXO(ctx, addrB, position)
+		utxo = mapper.GetUTXO(ctx, addrB, position)
 		assert.Nil(t, utxo)
 	}
 
@@ -118,16 +118,16 @@ func TestMultiUTXOAddDeleteDifferentBlock(t *testing.T) {
 		positionB := types.Position{uint64(i), 0, 0, 0}
 		utxo := types.NewBaseUTXO(addrB, confirmAddr, 100, positionB)
 		mapper.AddUTXO(ctx, utxo)
-		utxo = mapper.GetUTXO(ctx, positionB)
+		utxo = mapper.GetUTXO(ctx, addrB, positionB)
 		assert.NotNil(t, utxo)
 	}
 
 	for i := 0; i < 10; i++ {
 		position := types.Position{uint64(i), 0, 0, 0}
-		utxo := mapper.GetUTXO(ctx, position)
+		utxo := mapper.GetUTXO(ctx, addrB, position)
 		assert.NotNil(t, utxo)
-		mapper.DeleteUTXO(ctx, position)
-		utxo = mapper.GetUTXO(ctx, position)
+		mapper.DeleteUTXO(ctx, addrB, position)
+		utxo = mapper.GetUTXO(ctx, addrB, position)
 		assert.Nil(t, utxo)
 	}
 

--- a/types/mapper.go
+++ b/types/mapper.go
@@ -9,7 +9,7 @@ import (
 // retrieved from the context.
 type UTXOMapper interface {
 	GetUTXO(ctx sdk.Context, addr common.Address, position Position) UTXO
-	GetAllUTXOsForAddress(ctx sdk.Context, addr common.Address) []UTXO
+	GetUTXOsForAddress(ctx sdk.Context, addr common.Address) []UTXO
 	AddUTXO(ctx sdk.Context, utxo UTXO)
 	DeleteUTXO(ctx sdk.Context, addr common.Address, position Position)
 }

--- a/types/mapper.go
+++ b/types/mapper.go
@@ -2,12 +2,13 @@ package types
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // UTXOMapper stores and retrieves UTXO's from stores
 // retrieved from the context.
 type UTXOMapper interface {
-	GetUTXO(ctx sdk.Context, position Position) UTXO
+	GetUTXO(ctx sdk.Context, addr common.Address, position Position) UTXO
 	AddUTXO(ctx sdk.Context, utxo UTXO)
-	DeleteUTXO(ctx sdk.Context, position Position)
+	DeleteUTXO(ctx sdk.Context, addr common.Address, position Position)
 }

--- a/types/mapper.go
+++ b/types/mapper.go
@@ -9,6 +9,7 @@ import (
 // retrieved from the context.
 type UTXOMapper interface {
 	GetUTXO(ctx sdk.Context, addr common.Address, position Position) UTXO
+	GetAllUTXOsForAddress(ctx sdk.Context, addr common.Address) []UTXO
 	AddUTXO(ctx sdk.Context, utxo UTXO)
 	DeleteUTXO(ctx sdk.Context, addr common.Address, position Position)
 }


### PR DESCRIPTION
implement #47:
- switch UTXOMapper keys to use (address bytes + encoded position)
- still need to implement account abstraction on the client side.