### PR TITLE
Colin/ante

### DIFF
--- a/auth/ante.go
+++ b/auth/ante.go
@@ -93,7 +93,7 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 			inputs += indenom2
 		}
 
-		if inputs != spendMsg.Denom1+spendMsg.Denom2+spendMsg.Fee {
+		if inputs != (spendMsg.Denom1 + spendMsg.Denom2 + spendMsg.Fee) {
 			return ctx, sdk.ErrUnauthorized("inputs are not equal to outputs plus the fee").Result(), true
 		}
 

--- a/auth/ante.go
+++ b/auth/ante.go
@@ -55,7 +55,7 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 		}
 
 		res = processSig(addr1, sigs[0], signBytes)
-		
+
 		if !res.IsOK() {
 			return ctx, res, true
 		}
@@ -89,13 +89,13 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 			if !res.IsOK() {
 				return ctx, res, true
 			}
-			
+
 			inputs += indenom2
 		}
-		
-		if inputs != spendMsg.Denom1 + spendMsg.Denom2 + spendMsg.Fee {
+
+		if inputs != spendMsg.Denom1+spendMsg.Denom2+spendMsg.Fee {
 			return ctx, sdk.ErrUnauthorized("inputs are not equal to outputs plus the fee").Result(), true
-		} 
+		}
 
 		// Increment amount of fees collected
 		if !ctx.IsCheckTx() {
@@ -108,7 +108,7 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 }
 
 func processSig(
- 	addr common.Address, sig types.Signature, signBytes []byte) (
+	addr common.Address, sig types.Signature, signBytes []byte) (
 	res sdk.Result) {
 
 	hash := ethcrypto.Keccak256(signBytes)
@@ -165,4 +165,3 @@ func checkUTXO(ctx sdk.Context, mapper types.UTXOMapper, position types.Position
 
 	return utxo.GetDenom(), sdk.Result{}
 }
-

--- a/auth/ante.go
+++ b/auth/ante.go
@@ -47,9 +47,11 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 		signBytes := spendMsg.GetSignBytes()
 
 		// Verify the first input signature
+		addr1 := common.BytesToAddress(signerAddrs[0].Bytes())
 		position1 := types.Position{spendMsg.Blknum1, spendMsg.Txindex1, spendMsg.Oindex1, spendMsg.DepositNum1}
-		res := processSig(ctx, utxoMapper, position1, common.BytesToAddress(signerAddrs[0].Bytes()), sigs[0], signBytes)
-
+		indenom1, res := checkUTXO(ctx, utxoMapper, position1, addr1)
+		res = processSig(ctx, utxoMapper, addr1, sigs[0], signBytes)
+		
 		if !res.IsOK() {
 			return ctx, res, true
 		}
@@ -60,10 +62,15 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 		if !res.IsOK() {
 			return ctx, res, true
 		}
+
+		inputs := indenom1
+
 		// Verify the second input
 		if utils.ValidAddress(spendMsg.Owner2) {
 			position2 := types.Position{spendMsg.Blknum2, spendMsg.Txindex2, spendMsg.Oindex2, spendMsg.DepositNum2}
-			res = processSig(ctx, utxoMapper, position2, common.BytesToAddress(signerAddrs[1].Bytes()), sigs[1], signBytes)
+			addr2 := common.BytesToAddress(signerAddrs[1].Bytes())
+			indenom2, res := checkUTXO(ctx, utxoMapper, position2, addr2)
+			res = processSig(ctx, utxoMapper, addr2, sigs[1], signBytes)
 			if !res.IsOK() {
 				return ctx, res, true
 			}
@@ -74,7 +81,13 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 			if !res.IsOK() {
 				return ctx, res, true
 			}
+			
+			inputs += indenom2
 		}
+		
+		if inputs != spendMsg.Denom1 + spendMsg.Denom2 + spendMsg.Fee {
+			return ctx, sdk.ErrUnauthorized("inputs are not equal to outputs plus the fee").Result(), true
+		} 
 
 		// Increment amount of fees collected
 		if !ctx.IsCheckTx() {
@@ -88,19 +101,8 @@ func NewAnteHandler(utxoMapper types.UTXOMapper, txIndex *uint16, feeAmount *uin
 
 func processSig(
 	ctx sdk.Context, um types.UTXOMapper,
-	position types.Position, addr common.Address, sig types.Signature, signBytes []byte) (
+ 	addr common.Address, sig types.Signature, signBytes []byte) (
 	res sdk.Result) {
-
-	// Verify utxo exists
-	utxo := um.GetUTXO(ctx, position)
-	if utxo == nil {
-		return sdk.ErrUnknownRequest("UTXO trying to be spent, does not exist").Result()
-	}
-
-	// Verify that utxo owner equals input address in the transaction
-	if !reflect.DeepEqual(utxo.GetAddress().Bytes(), addr.Bytes()) {
-		return sdk.ErrUnauthorized("signer does not match utxo owner").Result()
-	}
 
 	hash := ethcrypto.Keccak256(signBytes)
 	pubKey1, err1 := ethcrypto.SigToPub(hash, sig.Bytes())
@@ -140,3 +142,18 @@ func processConfirmSig(
 
 	return sdk.Result{}
 }
+
+func checkUTXO(ctx sdk.Context, utxoMapper types.UTXOMapper, position types.Position, addr common.Address) (indenom uint64, res sdk.Result) {
+	utxo := utxoMapper.GetUTXO(ctx, position)
+	if utxo == nil {
+		return 0, sdk.ErrUnknownRequest("UTXO trying to be spend, does not exist").Result()
+	}
+
+	// Verify that utxo owner equals input address in the transaction
+	if !reflect.DeepEqual(utxo.GetAddress().Bytes(), addr.Bytes()) {
+		return 0, sdk.ErrUnauthorized("signer does not match utxo owner").Result()
+	}
+
+	return utxo.GetDenom(), sdk.Result{}
+}
+

--- a/auth/ante_test.go
+++ b/auth/ante_test.go
@@ -275,7 +275,7 @@ func TestValidTransaction(t *testing.T) {
 }
 
 // Check for double input that ante handler will
-// prevent any malformed transactions with unequal 
+// prevent any malformed transactions with unequal
 // input output fee balance from being spent
 func TestDenomEquality(t *testing.T) {
 	ctx, mapper, txIndex, feeAmount := setup()
@@ -336,4 +336,3 @@ func TestDenomEquality(t *testing.T) {
 	assert.Equal(t, true, abort, "did not abort with invalid transaction")
 	assert.Equal(t, sdk.ToABCICode(sdk.CodespaceType(1), sdk.CodeType(4)), res.Code, res.Log)
 }
-

--- a/auth/ante_test.go
+++ b/auth/ante_test.go
@@ -186,7 +186,7 @@ func TestValidSingleInput(t *testing.T) {
 		Owner2:       common.Address{},
 		ConfirmSigs2: confirmSigs,
 		Newowner1:    utils.PrivKeyToAddress(privKeyA),
-		Denom1:       150,
+		Denom1:       50,
 		Newowner2:    utils.PrivKeyToAddress(privKeyA),
 		Denom2:       45,
 		Fee:          5,

--- a/auth/ante_test.go
+++ b/auth/ante_test.go
@@ -273,3 +273,67 @@ func TestValidTransaction(t *testing.T) {
 	assert.Equal(t, false, abort, "aborted with valid transaction")
 	assert.Equal(t, sdk.ToABCICode(sdk.CodespaceType(1), sdk.CodeType(0)), res.Code, res.Log)
 }
+
+// Check for double input that ante handler will
+// prevent any malformed transactions with unequal 
+// input output fee balance from being spent
+func TestDenomEquality(t *testing.T) {
+	ctx, mapper, txIndex, feeAmount := setup()
+
+	privKeyA, _ := ethcrypto.GenerateKey() //Input Owner
+	privKeyB, _ := ethcrypto.GenerateKey() //ConfirmSig owner and recipient
+
+	// Generate valid inputs
+	position1 := types.Position{1, 0, 0, 0}
+	position2 := types.Position{1, 1, 0, 0}
+	confirmSigHash1 := ethcrypto.Keccak256(position1.GetSignBytes())
+	confirmSigHash2 := ethcrypto.Keccak256(position2.GetSignBytes())
+	confirmSig1, err := ethcrypto.Sign(confirmSigHash1, privKeyB)
+	require.NoError(t, err)
+	confirmSig2, err := ethcrypto.Sign(confirmSigHash2, privKeyB)
+	require.NoError(t, err)
+	confirmSigs1 := [2]types.Signature{types.Signature{confirmSig1}, types.Signature{confirmSig1}}
+	confirmSigs2 := [2]types.Signature{types.Signature{confirmSig2}, types.Signature{confirmSig2}}
+
+	//Single input
+	var msg = types.SpendMsg{
+		Blknum1:      1,
+		Txindex1:     0,
+		Oindex1:      0,
+		DepositNum1:  0,
+		Owner1:       utils.PrivKeyToAddress(privKeyA),
+		ConfirmSigs1: confirmSigs1,
+		Blknum2:      1,
+		Txindex2:     1,
+		Oindex2:      0,
+		DepositNum2:  0,
+		Owner2:       utils.PrivKeyToAddress(privKeyA),
+		ConfirmSigs2: confirmSigs2,
+		Newowner1:    utils.PrivKeyToAddress(privKeyB),
+		Denom1:       150,
+		Newowner2:    utils.PrivKeyToAddress(privKeyB),
+		Denom2:       50,
+		Fee:          5,
+	}
+	hash := ethcrypto.Keccak256(msg.GetSignBytes())
+	sig, err := ethcrypto.Sign(hash, privKeyA)
+	require.NoError(t, err)
+	tx := types.NewBaseTx(msg, []types.Signature{types.Signature{sig}, types.Signature{sig}})
+
+	handler := NewAnteHandler(mapper, txIndex, feeAmount)
+	_, res, abort := handler(ctx, tx)
+
+	assert.Equal(t, true, abort, "did not abort on utxo that does not exist")
+	assert.Equal(t, sdk.ToABCICode(sdk.CodespaceType(1), sdk.CodeType(6)), res.Code, res.Log)
+
+	utxo1 := newUTXO(privKeyB, privKeyA, position1)
+	utxo2 := newUTXO(privKeyB, privKeyA, position2)
+	mapper.AddUTXO(ctx, utxo1)
+	mapper.AddUTXO(ctx, utxo2)
+
+	_, res, abort = handler(ctx, tx)
+
+	assert.Equal(t, true, abort, "did not abort with invalid transaction")
+	assert.Equal(t, sdk.ToABCICode(sdk.CodespaceType(1), sdk.CodeType(4)), res.Code, res.Log)
+}
+


### PR DESCRIPTION
Refactored ante.go slightly. ProcessSig() now only handles checking that the signature is signed over the transaction and that it comes from the address provided in the spendmsg. 

CheckUTXO() will check the existence of a utxo and that the address for the utxo matches that of the address provided. It returns the denomination of the utxo which then can be used to ensure that
inputs = outputs + fee.

I added a test to check that it indeed does fail if the equation above does not hold. 

This can be squashed a merged if approved. 