### PR TITLE
Colin/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The light client uses the Ethereum keystore to create and store passphrase encry
 See our [research repository](https://github.com/FourthState/plasma-research) for architectural explanations of our Plasma implementation. 
 
 ### Documentation
-See our [documentation](https://github.com/FourthState/plasma-mvp-sidechain/blob/master/documentation.md)
+See our [documentation](https://github.com/FourthState/plasma-mvp-sidechain/blob/master/docs/overview.md)
 
 ### Contributing
 See our [contributing guidelines](https://github.com/FourthState/plasma-mvp-sidechain/blob/master/CONTRIBUTING.md)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -28,10 +28,10 @@ func newChildChain() *ChildChain {
 }
 
 // Creates a deposit of value 100 for each address in input
-func InitTestChain(addrs []common.Address, cc *ChildChain) {
+func InitTestChain(cc *ChildChain, addrs ...common.Address) {
 	var genUTXOs []GenesisUTXO
-	for i := 0; i < len(addrs); i++ {
-		genUTXOs = append(genUTXOs, NewGenesisUTXO(addrs[i].Hex(), "100", [4]string{"0", "0", "0", fmt.Sprintf("%d", i+1)}))
+	for i, addr := range addrs {
+		genUTXOs = append(genUTXOs, NewGenesisUTXO(addr.Hex(), "100", [4]string{"0", "0", "0", fmt.Sprintf("%d", i+1)}))
 	}
 
 	genState := GenesisState{
@@ -149,7 +149,7 @@ func TestSpendDeposit(t *testing.T) {
 	addrA := utils.PrivKeyToAddress(privKeyA)
 	addrB := utils.PrivKeyToAddress(privKeyB)
 
-	InitTestChain([]common.Address{addrA}, cc)
+	InitTestChain(cc, addrA)
 
 	msg := GenerateSimpleMsg(addrA, addrB, [4]uint64{0, 0, 0, 1}, 100, 0)
 
@@ -200,7 +200,7 @@ func TestSpendTx(t *testing.T) {
 	addrA := utils.PrivKeyToAddress(privKeyA)
 	addrB := utils.PrivKeyToAddress(privKeyB)
 
-	InitTestChain([]common.Address{addrA}, cc)
+	InitTestChain(cc, addrA)
 	cc.Commit()
 
 	msg := GenerateSimpleMsg(addrA, addrB, [4]uint64{0, 0, 0, 1}, 100, 0)
@@ -276,7 +276,7 @@ func TestDifferentTxForms(t *testing.T) {
 		addrs = append(addrs, utils.PrivKeyToAddress(keys[i]))
 	}
 
-	InitTestChain(addrs, cc)
+	InitTestChain(cc, addrs...)
 	cc.Commit()
 
 	cases := []struct {
@@ -392,7 +392,7 @@ func TestMultiTxBlocks(t *testing.T) {
 		addrs = append(addrs, utils.PrivKeyToAddress(keys[i]))
 	}
 
-	InitTestChain(addrs, cc)
+	InitTestChain(cc, addrs...)
 	cc.Commit()
 	cc.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: 1}})
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -294,15 +294,24 @@ func TestDifferentTxForms(t *testing.T) {
 		newowner2      common.Address
 		denom2         uint64
 	}{
-		// 1 input 2 output
+		// Test Case 0: 1 input 2 output
+		// Tx spends the genesis deposit and creates 2 new ouputs for addr[1] and addr[2]
 		{0, types.NewPosition(0, 0, 0, 1), 0, 0, 0, common.Address{}, types.Position{}, 0, 0, addrs[1], 20, addrs[2], 80},
-		// 2 different inputs, 1 output
+
+		// Test Case 1: 2 different inputs, 1 output
+		// Tx spends outputs from test case 0 and creates 1 output for addr[3]
 		{1, types.NewPosition(7, 0, 0, 0), 0, 0, 2, addrs[2], types.NewPosition(7, 0, 1, 0), 0, 0, addrs[3], 100, common.Address{}, 0},
-		// 1 input 2 ouput
+
+		// Test Case 2: 1 input 2 ouput
+		// Tx spends output from test case 1 and creates 2 new outputs for addr[3] and addr[4]
 		{3, types.NewPosition(8, 0, 0, 0), 1, 2, 0, common.Address{}, types.Position{}, 0, 0, addrs[3], 75, addrs[4], 25},
-		// 2 different inputs 2 outputs
+
+		// Test Case 3: 2 different inputs 2 outputs
+		// Tx spends outputs from test case 2 and creates 2 new outputs both for addr[3]
 		{3, types.NewPosition(9, 0, 0, 0), 3, 0, 4, addrs[4], types.NewPosition(9, 0, 1, 0), 3, 0, addrs[3], 70, addrs[3], 30},
-		// 2 same inputs, 1 output (merge)
+
+		// Test Case 4: 2 same inputs, 1 output (merge)
+		// Tx spends outputs from test case 3 and creates 1 new output for addr[3]
 		{3, types.NewPosition(10, 0, 0, 0), 3, 4, 3, addrs[3], types.NewPosition(10, 0, 1, 0), 3, 4, addrs[3], 100, common.Address{}, 0},
 	}
 
@@ -345,21 +354,21 @@ func TestDifferentTxForms(t *testing.T) {
 		// Retrieve utxo from context
 		utxo := cc.utxoMapper.GetUTXO(ctx, tc.newowner1, types.NewPosition(uint64(index)+7, 0, 0, 0))
 		expected := types.NewBaseUTXO(tc.newowner1, [2]common.Address{msg.Owner1, msg.Owner2}, tc.denom1, types.NewPosition(uint64(index)+7, 0, 0, 0))
-		require.Equal(t, expected, utxo, "First UTXO did not get added to the utxo store correctly")
+		require.Equal(t, expected, utxo, fmt.Sprintf("First UTXO did not get added to the utxo store correctly. Failed on test case: %d", index))
 
 		if !utils.ZeroAddress(msg.Newowner2) {
 			utxo = cc.utxoMapper.GetUTXO(ctx, tc.newowner2, types.NewPosition(uint64(index)+7, 0, 1, 0))
 			expected = types.NewBaseUTXO(tc.newowner2, [2]common.Address{msg.Owner1, msg.Owner2}, tc.denom2, types.NewPosition(uint64(index)+7, 0, 1, 0))
-			require.Equal(t, expected, utxo, "Second UTXO did not get added to the utxo store correctly")
+			require.Equal(t, expected, utxo, fmt.Sprintf("Second UTXO did not get added to the utxo store correctly. Failed on test case: %d", index))
 		}
 
 		// Check that inputs were removed
 		utxo = cc.utxoMapper.GetUTXO(ctx, msg.Owner1, tc.position1)
-		require.Nil(t, utxo, "first input was not removed from the utxo store")
+		require.Nil(t, utxo, fmt.Sprintf("first input was not removed from the utxo store. Failed on test case: %d", index))
 
 		if !utils.ZeroAddress(msg.Owner2) {
 			utxo = cc.utxoMapper.GetUTXO(ctx, msg.Owner2, tc.position2)
-			require.Nil(t, utxo, "second input was not removed from the utxo store")
+			require.Nil(t, utxo, fmt.Sprintf("second input was not removed from the utxo store. Failed on test case: %d", index))
 		}
 
 		cc.EndBlock(abci.RequestEndBlock{})

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"crypto/ecdsa"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
@@ -64,6 +65,24 @@ func GenerateSimpleMsg(Owner1, NewOwner1 common.Address, position [4]uint64, den
 		Denom2:       0,
 		Fee:          fee,
 	}
+}
+
+// returns a confirmsig array signed by privKey. two should be true if two positions are passed in.
+// Assumes at least first position is passed in
+func CreateConfirmSig(position1, position2 types.Position, privKey *ecdsa.PrivateKey, two bool) (confirmSigs [2]types.Signature) {
+	confirmBytes := position1.GetSignBytes()
+	hash := ethcrypto.Keccak256(confirmBytes)
+	confirmSig, _ := ethcrypto.Sign(hash, privKey)
+	if two {
+		confirmBytes2 := position2.GetSignBytes()
+		hash2 := ethcrypto.Keccak256(confirmBytes2)
+		confirmSig2, _ := ethcrypto.Sign(hash2, privKey)
+		confirmSigs = [2]types.Signature{types.Signature{confirmSig}, types.Signature{confirmSig2}}
+	} else {
+		confirmSigs = [2]types.Signature{types.Signature{confirmSig}, types.Signature{}}
+	}
+
+	return confirmSigs
 }
 
 // Attempts to spend a non-existent utxo
@@ -234,5 +253,132 @@ func TestSpendTx(t *testing.T) {
 	expected := types.NewBaseUTXO(addrA, [2]common.Address{addrB, common.Address{}}, 100, types.NewPosition(5, 0, 0, 0))
 
 	require.Equal(t, expected, utxo, "UTXO did not get added to store correctly")
+
+}
+
+// Tests 1 input 2 ouput, 2 input (different addresses) 1 output,
+// 2 input (different addresses) 2 ouputs, and 2 input (same address) 1 ouput
+func TestDifferentTxForms(t *testing.T) {
+	// Initialize child chain with deposit
+	cc := newChildChain()
+	var keys [6]*ecdsa.PrivateKey
+	var addrs [6]common.Address
+
+	for i := 0; i < 6; i++ {
+		keys[i], _ = ethcrypto.GenerateKey()
+		addrs[i] = utils.PrivKeyToAddress(keys[i])
+	}
+
+	InitTestChain(addrs[0], cc)
+	cc.Commit()
+
+	// Create confirm signature
+	confirmSig1 := CreateConfirmSig(types.NewPosition(0, 0, 0, 1), types.Position{0, 0, 0, 1}, keys[0], true)
+
+	// Create first tx, 1 input 2 output
+	msg := types.SpendMsg{
+		Blknum1:      0,
+		Txindex1:     uint16(0),
+		Oindex1:      uint8(0),
+		DepositNum1:  1,
+		Owner1:       addrs[0],
+		ConfirmSigs1: confirmSig1,
+		Blknum2:      0,
+		Txindex2:     0,
+		Oindex2:      0,
+		DepositNum2:  0,
+		Owner2:       common.Address{},
+		ConfirmSigs2: [2]types.Signature{types.Signature{}, types.Signature{}},
+		Newowner1:    addrs[1],
+		Denom1:       20,
+		Newowner2:    addrs[2],
+		Denom2:       80,
+		Fee:          0,
+	}
+
+	// Sign the hash of the transaction
+	hash := ethcrypto.Keccak256(msg.GetSignBytes())
+	sig, _ := ethcrypto.Sign(hash, keys[0])
+	tx := types.NewBaseTx(msg, []types.Signature{{
+		Sig: sig,
+	}})
+
+	cc.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: 7}})
+
+	// Run a check
+	cres := cc.Check(tx)
+	require.Equal(t, sdk.CodeType(0), sdk.CodeType(cres.Code), cres.Log)
+
+	dres := cc.Deliver(tx)
+
+	require.Equal(t, sdk.CodeType(0), sdk.CodeType(dres.Code), dres.Log)
+
+	// Create context
+	ctx := cc.NewContext(false, abci.Header{})
+
+	// Retrieve UTXO from context
+	utxo1 := cc.utxoMapper.GetUTXO(ctx, addrs[1], types.NewPosition(7, 0, 0, 0))
+	expected1 := types.NewBaseUTXO(addrs[1], [2]common.Address{addrs[0], common.Address{}}, 20, types.NewPosition(7, 0, 0, 0))
+	utxo2 := cc.utxoMapper.GetUTXO(ctx, addrs[2], types.NewPosition(7, 0, 1, 0))
+	expected2 := types.NewBaseUTXO(addrs[2], [2]common.Address{addrs[0], common.Address{}}, 80, types.NewPosition(7, 0, 1, 0))
+
+	require.Equal(t, expected1, utxo1, "First UTXO did not get added to store correctly")
+	require.Equal(t, expected2, utxo2, "Second UTXO did not get added to store correctly")
+
+	cc.EndBlock(abci.RequestEndBlock{})
+	cc.Commit()
+
+	// 2 different inputs 1 output
+	confirmSig1 = CreateConfirmSig(types.NewPosition(7, 0, 0, 0), types.Position{}, keys[0], false)
+	confirmSig2 := CreateConfirmSig(types.NewPosition(7, 0, 1, 0), types.Position{}, keys[0], false)
+
+	msg = types.SpendMsg{
+		Blknum1:      7,
+		Txindex1:     uint16(0),
+		Oindex1:      uint8(0),
+		DepositNum1:  0,
+		Owner1:       addrs[1],
+		ConfirmSigs1: confirmSig1,
+		Blknum2:      7,
+		Txindex2:     uint16(0),
+		Oindex2:      uint8(1),
+		DepositNum2:  0,
+		Owner2:       addrs[2],
+		ConfirmSigs2: confirmSig2,
+		Newowner1:    addrs[3],
+		Denom1:       100,
+		Newowner2:    common.Address{},
+		Denom2:       0,
+		Fee:          0,
+	}
+
+	// Sign the hash of the transaction
+	hash = ethcrypto.Keccak256(msg.GetSignBytes())
+	sig1, _ := ethcrypto.Sign(hash, keys[1])
+	sig2, _ := ethcrypto.Sign(hash, keys[2])
+	tx = types.NewBaseTx(msg, []types.Signature{{
+		Sig: sig1,
+	}, {
+		Sig: sig2,
+	}})
+
+	cc.BeginBlock(abci.RequestBeginBlock{Header: abci.Header{Height: 8}})
+
+	// Run a check
+	cres = cc.Check(tx)
+	require.Equal(t, sdk.CodeType(0), sdk.CodeType(cres.Code), cres.Log)
+
+	dres = cc.Deliver(tx)
+
+	require.Equal(t, sdk.CodeType(0), sdk.CodeType(dres.Code), dres.Log)
+
+	// Create context
+	ctx = cc.NewContext(false, abci.Header{})
+
+	// Retrieve UTXO from context
+	utxo1 = cc.utxoMapper.GetUTXO(ctx, addrs[3], types.NewPosition(8, 0, 0, 0))
+	expected1 = types.NewBaseUTXO(addrs[3], [2]common.Address{addrs[1], addrs[2]}, 100, types.NewPosition(8, 0, 0, 0))
+
+	require.Equal(t, expected1, utxo1, "UTXO with 2 different inputs did not get added to the store correctly")
 
 }

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -44,7 +44,7 @@ func ToUTXO(gutxo GenesisUTXO) types.UTXO {
 	addr := common.HexToAddress(gutxo.Address)
 	denom, _ := strconv.ParseUint(gutxo.Denom, 10, 64)
 	utxo := &types.BaseUTXO{
-		InputAddresses: [2]common.Address{addr, addr},
+		InputAddresses: [2]common.Address{addr, common.Address{}},
 		Address:        addr,
 		Denom:          denom,
 	}

--- a/types/tx.go
+++ b/types/tx.go
@@ -43,9 +43,6 @@ func (msg SpendMsg) ValidateBasic() sdk.Error {
 	if msg.Blknum1 == msg.Blknum2 && msg.Txindex1 == msg.Txindex2 && msg.Oindex1 == msg.Oindex2 && msg.DepositNum1 == msg.DepositNum2 {
 		return ErrInvalidTransaction(DefaultCodespace, "Cannot spend same position twice")
 	}
-	if msg.Blknum1 == msg.Blknum2 && msg.Txindex1 == msg.Txindex2 && msg.Oindex1 == msg.Oindex2 && msg.DepositNum1 == msg.DepositNum2 {
-		return ErrInvalidTransaction(DefaultCodespace, "Cannot spend same position twice")
-	}
 
 	switch {
 

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -116,6 +116,11 @@ func TestInvalidSpendDeposit(t *testing.T) {
 
 	err := msg1.ValidateBasic()
 	require.Equal(t, sdk.CodeType(106), err.Code(), err.Error())
+
+	msg1.DepositNum1 = 0
+	msg1.DepositNum2 = 123
+	err = msg1.ValidateBasic()
+	require.Equal(t, sdk.CodeType(106), err.Code(), err.Error())
 }
 
 // Creates an invalid transaction spending same position twice
@@ -126,6 +131,15 @@ func TestInvalidPosition(t *testing.T) {
 
 	err := msg1.ValidateBasic()
 	require.Equal(t, sdk.CodeType(106), err.Code(), err.Error())
+}
+
+// Try to spend with 0 denomination for first output
+func TestInvalidDenomination(t *testing.T) {
+	var msg1 = GenSpendMsgWithAddresses()
+	msg1.Denom1 = 0
+
+	err := msg1.ValidateBasic()
+	require.Equal(t, sdk.CodeType(103), err.Code(), err.Error())
 }
 
 // Tests GetSigners method

--- a/types/utxo.go
+++ b/types/utxo.go
@@ -50,7 +50,7 @@ func (utxo *BaseUTXO) GetAddress() common.Address {
 
 //Implements UTXO
 func (utxo *BaseUTXO) SetAddress(addr common.Address) error {
-	if utils.ZeroAddress(utxo.Address) {
+	if !utils.ZeroAddress(utxo.Address) {
 		return errors.New("cannot override BaseUTXO Address")
 	}
 	if utils.ZeroAddress(addr) {
@@ -60,8 +60,9 @@ func (utxo *BaseUTXO) SetAddress(addr common.Address) error {
 	return nil
 }
 
+//Implements UTXO
 func (utxo *BaseUTXO) SetInputAddresses(addrs [2]common.Address) error {
-	if utils.ZeroAddress(utxo.InputAddresses[0]) {
+	if !utils.ZeroAddress(utxo.InputAddresses[0]) {
 		return errors.New("cannot override BaseUTXO Address")
 	}
 	if utils.ZeroAddress(addrs[0]) {
@@ -71,6 +72,7 @@ func (utxo *BaseUTXO) SetInputAddresses(addrs [2]common.Address) error {
 	return nil
 }
 
+//Implements UTXO
 func (utxo *BaseUTXO) GetInputAddresses() [2]common.Address {
 	return utxo.InputAddresses
 }
@@ -83,19 +85,24 @@ func (utxo *BaseUTXO) GetDenom() uint64 {
 //Implements UTXO
 func (utxo *BaseUTXO) SetDenom(denom uint64) error {
 	if utxo.Denom != 0 {
-		return errors.New("Cannot override BaseUTXO denomination")
+		return errors.New("cannot override BaseUTXO denomination")
 	}
 	utxo.Denom = denom
 	return nil
 }
 
+//Implements UTXO
 func (utxo *BaseUTXO) GetPosition() Position {
 	return utxo.Position
 }
 
+//Implements UTXO
 func (utxo *BaseUTXO) SetPosition(blockNum uint64, txIndex uint16, oIndex uint8, depositNum uint64) error {
-	if utxo.Position.Blknum != 0 {
+	if utxo.Position.Blknum != 0 || utxo.Position.DepositNum != 0 {
 		return errors.New("cannot override BaseUTXO Position")
+	}
+	if blockNum == 0 && txIndex == 0 && oIndex == 0 && depositNum == 0 {
+		return errors.New("position cannot be set to 0, 0, 0, 0")
 	}
 	utxo.Position = Position{blockNum, txIndex, oIndex, depositNum}
 	return nil

--- a/types/utxo_test.go
+++ b/types/utxo_test.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/FourthState/plasma-mvp-sidechain/utils"
+	"github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// Basic tests checking methods for BaseUTXO
+func TestUTXO(t *testing.T) {
+	privKeyA, _ := ethcrypto.GenerateKey()
+	privKeyB, _ := ethcrypto.GenerateKey()
+	addrA := utils.PrivKeyToAddress(privKeyA)
+	addrB := utils.PrivKeyToAddress(privKeyB)
+	utxo := NewBaseUTXO(common.Address{}, [2]common.Address{common.Address{}, common.Address{}}, 100, NewPosition(0, 0, 0, 0))
+
+	// try to set address to another blank address
+	err := utxo.SetAddress(common.Address{})
+	require.EqualError(t, err, "address provided is nil")
+
+	// set address to addrB
+	err = utxo.SetAddress(addrB)
+	require.NoError(t, err)
+
+	// try to set address to addrA (currently set to addrB)
+	err = utxo.SetAddress(addrA)
+	require.EqualError(t, err, "cannot override BaseUTXO Address")
+
+	// check get method
+	addr := utxo.GetAddress()
+	require.Equal(t, addr, addrB, fmt.Sprintf("BaseUTXO GetAddress() method returned the wrong address: %s", addr))
+
+	// try to set input address to blank addresses
+	err = utxo.SetInputAddresses([2]common.Address{common.Address{}, common.Address{}})
+	require.EqualError(t, err, "address provided is nil")
+
+	// set input addresses to addrA, addrA
+	err = utxo.SetInputAddresses([2]common.Address{addrA, addrA})
+	require.NoError(t, err)
+
+	// try to set input address to addrB
+	err = utxo.SetInputAddresses([2]common.Address{addrB, common.Address{}})
+	require.EqualError(t, err, "cannot override BaseUTXO Address")
+
+	// check get method
+	addrs := utxo.GetInputAddresses()
+	require.Equal(t, addrs, [2]common.Address{addrA, addrA})
+
+	// try to set denom when it already has a value
+	err = utxo.SetDenom(100000000)
+	require.EqualError(t, err, "cannot override BaseUTXO denomination")
+
+	// check get method
+	amount := utxo.GetDenom()
+	require.Equal(t, amount, uint64(100), "the wrong denomination was returned by GetDenom()")
+
+	// try to set position to incorrect position 0, 0, 0, 0
+	err = utxo.SetPosition(0, uint16(0), uint8(0), 0)
+	require.EqualError(t, err, "position cannot be set to 0, 0, 0, 0")
+
+	// set position
+	err = utxo.SetPosition(5, 12, 1, 0)
+	require.NoError(t, err)
+
+	// try to set to different position
+	err = utxo.SetPosition(1, 23, 1, 0)
+	require.EqualError(t, err, "cannot override BaseUTXO Position")
+
+	// check get method
+	position := utxo.GetPosition()
+	require.Equal(t, position, NewPosition(5, 12, 1, 0))
+
+}

--- a/types/utxo_test.go
+++ b/types/utxo_test.go
@@ -10,13 +10,18 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
-// Basic tests checking methods for BaseUTXO
-func TestUTXO(t *testing.T) {
+// return a base utxo with nothing set, along with two addresses
+func GetBareUTXO() (utxo UTXO, addrA, addrB common.Address) {
 	privKeyA, _ := ethcrypto.GenerateKey()
 	privKeyB, _ := ethcrypto.GenerateKey()
-	addrA := utils.PrivKeyToAddress(privKeyA)
-	addrB := utils.PrivKeyToAddress(privKeyB)
-	utxo := NewBaseUTXO(common.Address{}, [2]common.Address{common.Address{}, common.Address{}}, 100, NewPosition(0, 0, 0, 0))
+	addrA = utils.PrivKeyToAddress(privKeyA)
+	addrB = utils.PrivKeyToAddress(privKeyB)
+	return &BaseUTXO{}, addrA, addrB
+}
+
+// Basic tests checking methods for BaseUTXO
+func TestGetSetAddress(t *testing.T) {
+	utxo, addrA, addrB := GetBareUTXO()
 
 	// try to set address to another blank address
 	err := utxo.SetAddress(common.Address{})
@@ -33,9 +38,14 @@ func TestUTXO(t *testing.T) {
 	// check get method
 	addr := utxo.GetAddress()
 	require.Equal(t, addr, addrB, fmt.Sprintf("BaseUTXO GetAddress() method returned the wrong address: %s", addr))
+}
+
+// Test GetInputAddresses() and SetInputAddresses
+func TestInputAddresses(t *testing.T) {
+	utxo, addrA, addrB := GetBareUTXO()
 
 	// try to set input address to blank addresses
-	err = utxo.SetInputAddresses([2]common.Address{common.Address{}, common.Address{}})
+	err := utxo.SetInputAddresses([2]common.Address{common.Address{}, common.Address{}})
 	require.EqualError(t, err, "address provided is nil")
 
 	// set input addresses to addrA, addrA
@@ -49,17 +59,27 @@ func TestUTXO(t *testing.T) {
 	// check get method
 	addrs := utxo.GetInputAddresses()
 	require.Equal(t, addrs, [2]common.Address{addrA, addrA})
+}
+
+// Test GetDenom() and SetDenom()
+func TestDenom(t *testing.T) {
+	utxo := NewBaseUTXO(common.Address{}, [2]common.Address{common.Address{}, common.Address{}}, 100, Position{})
 
 	// try to set denom when it already has a value
-	err = utxo.SetDenom(100000000)
+	err := utxo.SetDenom(100000000)
 	require.EqualError(t, err, "cannot override BaseUTXO denomination")
 
 	// check get method
 	amount := utxo.GetDenom()
 	require.Equal(t, amount, uint64(100), "the wrong denomination was returned by GetDenom()")
+}
+
+// Test GetPosition() and SetPosition()
+func TestPosition(t *testing.T) {
+	utxo := BaseUTXO{}
 
 	// try to set position to incorrect position 0, 0, 0, 0
-	err = utxo.SetPosition(0, uint16(0), uint8(0), 0)
+	err := utxo.SetPosition(0, uint16(0), uint8(0), 0)
 	require.EqualError(t, err, "position cannot be set to 0, 0, 0, 0")
 
 	// set position
@@ -73,5 +93,4 @@ func TestUTXO(t *testing.T) {
 	// check get method
 	position := utxo.GetPosition()
 	require.Equal(t, position, NewPosition(5, 12, 1, 0))
-
 }


### PR DESCRIPTION
Added the following tests as outlined in #46:

- [x] One input, two ouputs
- [x] Two inputs (different addresses), one output
- [x] Two inputs (different addresses), two outputs
- [x] Merge tx (two inputs with the same address, one output with the same address)
- [x] Multiple tx's in single block (automated)
- [x] Tests for UTXO.go

The test which inserts multiple txs into one block is automated. You can adjust the number of txs by changing the value of N. Thought this might be useful for testing how long processing N amount of txs would take. 

Fixed minor bug in utxo.go that was incorrectly checking if the address or input address for a utxo had been set. I also added a couple tests for validate basic that were missing. 
