### PR TITLE
fixed syncing issues

### DIFF
--- a/eth/plasma.go
+++ b/eth/plasma.go
@@ -82,7 +82,8 @@ func (plasma *Plasma) OperatorAddress() (common.Address, error) {
 	return plasma.contract.Operator(nil)
 }
 
-// SubmitBlock proxy. Blocks are committed ever > commitment interval
+// CommitPlasmaHeaders will commit all new non-committed headers to the smart contract.
+// the commitmentRate interval must pass since the last commitment
 func (plasma *Plasma) CommitPlasmaHeaders(ctx sdk.Context, plasmaStore store.PlasmaStore) error {
 	// only the contract operator can submit blocks. The commitment duration must also pass
 	if plasma.operatorSession == nil || time.Since(plasma.lastBlockSubmission).Seconds() < plasma.commitmentRate.Seconds() {

--- a/server/app/options.go
+++ b/server/app/options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"strconv"
+	"time"
 )
 
 func SetPlasmaOptionsFromConfig(conf config.PlasmaConfig) func(*PlasmaMVPChain) {
@@ -38,10 +39,16 @@ func SetPlasmaOptionsFromConfig(conf config.PlasmaConfig) func(*PlasmaMVPChain) 
 		panic("invalid contract address. please use hex format")
 	}
 
+	dur, err := time.ParseDuration(conf.PlasmaCommitmentRate)
+	if err != nil {
+		panic("commitment rate must be able to be parsed into a golang Duration type")
+	}
+
 	return func(pc *PlasmaMVPChain) {
 		pc.operatorPrivateKey = privateKey
 		pc.isOperator = conf.IsOperator
 		pc.plasmaContractAddress = common.HexToAddress(conf.EthPlasmaContractAddr)
+		pc.blockCommitmentRate = dur
 		pc.nodeURL = conf.EthNodeURL
 		pc.blockFinality = blockFinality
 	}

--- a/server/plasmad/config/config.go
+++ b/server/plasmad/config/config.go
@@ -21,6 +21,9 @@ ethereum_operator_privatekey = "{{ .EthOperatorPrivateKey }}"
 # Ethereum plasma contract address
 ethereum_plasma_contract_address = "{{ .EthPlasmaContractAddr }}"
 
+# Plasma block commitment rate. i.e 1m30s, 1m, 1h, etc.
+plasma_block_commitment_rate = "{{ .PlasmaCommitmentRate }}"
+
 # Node URL for eth client
 ethereum_nodeurl = "{{ .EthNodeURL }}"
 
@@ -32,6 +35,7 @@ type PlasmaConfig struct {
 	IsOperator            bool   `mapstructure:"is_operator"`
 	EthOperatorPrivateKey string `mapstructure:"ethereum_operator_privatekey"`
 	EthPlasmaContractAddr string `mapstructure:"ethereum_plasma_contract_address"`
+	PlasmaCommitmentRate  string `mapstructure:"plasma_block_commitment_rate"`
 	EthNodeURL            string `mapstructure:"ethereum_nodeurl"`
 	EthBlockFinality      string `mapstructure:"ethereum_finality"`
 }
@@ -47,7 +51,7 @@ func init() {
 }
 
 func DefaultPlasmaConfig() PlasmaConfig {
-	return PlasmaConfig{false, "", "", "", "0"}
+	return PlasmaConfig{false, "", "", "", "", "0"}
 }
 
 // parses the plasma.toml file and unmarshals it into a Config struct


### PR DESCRIPTION
introduce a new commitment rate for plasma headers.

Once the commitment rate elapses, we attempt to commit all last plasma headers since the contract's lastCommittedBlock