### PR TITLE
R4R: added confirm sig client storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 ### Added
+- [plasmacli] Added keys subcommand with account mapping
+- [plasmacli] Added local confirmation signature storage
 - Ethereum connection to smart contract
 - Implemented Fees
 - Unit tests
@@ -12,13 +14,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Query sidechain state
 - Plasma configuration file
 ### Changed
-- [plasmacli] Added keys subcommand with account mapping
 - [plasmacli] home flag renamed to directory, flags have suffic "F" for local flags, and "Flag" for persistent flags
+- [plasmacli] client keystore/ renamed to store/
 - Made UTXO model modular
 - Transaction verification to be compatible with rootchain
 - Decrease dependency on amino encoding
 - Updated client
 - Updated documentation
+- Upgrade to v0.32.0 of Cosmos SDK
 
 ## PreHistory
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -147,7 +147,7 @@
   version = "v1.7.1"
 
 [[projects]]
-  digest = "1:81cdea2cb729a674dc6e3f9e85ca1169b6a13157676b5ff6e15f1561371a729d"
+  digest = "1:1530d06761f464b62ab3dfc2fa5b16303901d87ff219100a1447ba216d2e52be"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -162,12 +162,11 @@
     "common/prque",
     "core/types",
     "crypto",
-    "crypto/secp256k1",
     "crypto/secp256k1/libsecp256k1",
     "crypto/secp256k1/libsecp256k1/include",
     "crypto/secp256k1/libsecp256k1/src",
     "crypto/secp256k1/libsecp256k1/src/modules/recovery",
-    "crypto/sha3",
+    "crypto/secp256k1",
     "ethclient",
     "ethdb",
     "event",
@@ -179,9 +178,9 @@
     "rpc",
     "trie",
   ]
-  pruneopts = "UT"
-  revision = "24d727b6d6e2c0cde222fa12155c4a6db5caaf2e"
-  version = "v1.8.20"
+  pruneopts = "T"
+  revision = "c942700427557e3ff6de3aaf6b916e2f056c1ec2"
+  version = "v1.8.23"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -566,19 +565,20 @@
   version = "v0.14.1"
 
 [[projects]]
-  digest = "1:e1cc8dd891e64aab63b0c09f2f12456cbe2cd9cbd9d96dfae3281245f05c2428"
+  digest = "1:1bb088f6291e5426e3874a60bca0e481a91a5633395d7e0c427ec3e49b626e7b"
   name = "github.com/tendermint/iavl"
   packages = ["."]
   pruneopts = "UT"
-  revision = "de0740903a67b624d887f9055d4c60175dcfa758"
-  version = "v0.12.0"
+  revision = "ac7c35c12e8633a1e9fd0b52a00b900b40f32cd3"
+  version = "v0.12.1"
 
 [[projects]]
-  digest = "1:fbf8a69c035430a7f06fe0b725ef9ef1ea02366a35d35a0f4c2c2c77b5d1d9cb"
+  digest = "1:4a372b718ee1433fa421e1c9e450a8b14bc24f2b5d7b5f9329d4d49e360f5f9e"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
     "abci/example/code",
+    "abci/example/counter",
     "abci/example/kvstore",
     "abci/server",
     "abci/types",
@@ -639,8 +639,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "1e1ca15bccedc16c2452c73745c3c2b5df91ae96"
-  version = "v0.27.4"
+  revision = "e0f8936455029a40287a69d5b0e7baa4d5864da1"
+  version = "v0.30.1"
 
 [[projects]]
   digest = "1:5a736f4722932d9a45d28852e85b83f68292d9af2ef0be29d4e5fe6fd89d5d96"
@@ -667,7 +667,7 @@
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:9ee7b5b1fdcf6dcb0d609912076bb8da0c1c953a55141c7d83fa21dee29ad4f2"
+  digest = "1:a454511f589cc0cf4e4027920a2924cc70b45a51ae07d6dee38c5bdb0fdc1d86"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -688,6 +688,7 @@
     "ripemd160",
     "salsa20/salsa",
     "scrypt",
+    "sha3",
   ]
   pruneopts = "UT"
   revision = "3764759f34a542a3aef74d6b02e35be7ab893bba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,15 +2,15 @@
 
 
 [[projects]]
-  digest = "1:1156cfea0ff969858f6027df95c15ca5e802556b466aebeedaf53dde3b301db3"
+  digest = "1:f96ba6ecca7ba87b1dddd70ae38cfc4ce5ea844f58d1f728e121d2e29cdfb8a2"
   name = "github.com/allegro/bigcache"
   packages = [
     ".",
     "queue",
   ]
   pruneopts = "UT"
-  revision = "f31987a23e44c5121ef8c8b2f2ea2e8ffa37b068"
-  version = "v1.1.0"
+  revision = "84a0ff3f153cbd7e280a19029a864bb04b504e62"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -18,7 +18,7 @@
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
   pruneopts = "UT"
-  revision = "0ca71131d8f76e0739563d97cc9f95c021825a2b"
+  revision = "728bce664cf5dfb921941b240828f989a2c8f8e3"
 
 [[projects]]
   branch = "master"
@@ -147,7 +147,7 @@
   version = "v1.7.1"
 
 [[projects]]
-  digest = "1:1530d06761f464b62ab3dfc2fa5b16303901d87ff219100a1447ba216d2e52be"
+  digest = "1:8bf83050739ffd7f13bdc7dd281fccc40718d52eb2ce23fe7d980a3ac1f0a8b0"
   name = "github.com/ethereum/go-ethereum"
   packages = [
     ".",
@@ -162,11 +162,8 @@
     "common/prque",
     "core/types",
     "crypto",
-    "crypto/secp256k1/libsecp256k1",
-    "crypto/secp256k1/libsecp256k1/include",
-    "crypto/secp256k1/libsecp256k1/src",
-    "crypto/secp256k1/libsecp256k1/src/modules/recovery",
     "crypto/secp256k1",
+    "crypto/sha3",
     "ethclient",
     "ethdb",
     "event",
@@ -179,8 +176,8 @@
     "trie",
   ]
   pruneopts = "T"
-  revision = "c942700427557e3ff6de3aaf6b916e2f056c1ec2"
-  version = "v1.8.23"
+  revision = "dae82f098570e15d44584f0d7f350713f4774727"
+  version = "v1.8.19"
 
 [[projects]]
   digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
@@ -252,12 +249,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  digest = "1:e4f5819333ac698d294fe04dbf640f84719658d5c7ce195b10060cc37292ce79"
   name = "github.com/golang/snappy"
   packages = ["."]
   pruneopts = "UT"
-  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+  revision = "2a8bb927dd31d8daada140a5d09578521ce5c36a"
+  version = "v0.0.1"
 
 [[projects]]
   digest = "1:236d7e1bdb50d8f68559af37dbcf9d142d56b431c9b2176d41e2a009b664cda8"
@@ -268,20 +265,12 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:c79fb010be38a59d657c48c6ba1d003a8aa651fa56b579d959d74573b7dff8e1"
-  name = "github.com/gorilla/context"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
-  version = "v1.1.1"
-
-[[projects]]
-  digest = "1:e73f5b0152105f18bc131fba127d9949305c8693f8a762588a82a48f61756f5f"
+  digest = "1:ca59b1175189b3f0e9f1793d2c350114be36eaabbe5b9f554b35edee1de50aea"
   name = "github.com/gorilla/mux"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
-  version = "v1.6.2"
+  revision = "a7962380ca08b5a188038c69871b8d3fbdf31e89"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:7b5c6e2eeaa9ae5907c391a91c132abfd5c9e8a784a341b5625e750c67e6825d"
@@ -343,12 +332,12 @@
   version = "v1.8.0"
 
 [[projects]]
-  digest = "1:0981502f9816113c9c8c4ac301583841855c8cf4da8c72f696b3ebedf6d0e4e5"
+  digest = "1:3bb9c8451d199650bfd303e0068d86f135952fead374ad87c09a9b8a2cc4bd7c"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
-  version = "v0.0.4"
+  revision = "369ecd8cea9851e459abb67eb171853e3986591e"
+  version = "v0.0.6"
 
 [[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
@@ -416,11 +405,10 @@
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = "UT"
-  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+  revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:33c81bf709f084827a560e14415b1d7001a6d1d6fa4bec2cc2e60b84ecbc0e0a"
+  digest = "1:35cf6bdf68db765988baa9c4f10cc5d7dda1126a54bd62e252dbcd0b1fc8da90"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -428,20 +416,22 @@
     "model",
   ]
   pruneopts = "UT"
-  revision = "67670fe90761d7ff18ec1d640135e53b9198328f"
+  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:d39e7c7677b161c2dd4c635a2ac196460608c7d8ba5337cc8cae5825a2681f8f"
+  digest = "1:ca30ee2c96d195cef49b546d10825d3e13b50c63da4df23c80e77c51e07bad0d"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
+    "iostats",
     "nfs",
     "xfs",
   ]
   pruneopts = "UT"
-  revision = "1dc9a6cbc91aacc3e8b2d63db4d2e957a5394ac4"
+  revision = "6ed1f7e1041181781dd2826d3001075d011a80cc"
 
 [[projects]]
   digest = "1:c4556a44e350b50a490544d9b06e9fba9c286c21d6c0e47f54f3a9214597298c"
@@ -467,15 +457,15 @@
   version = "v1.6.0"
 
 [[projects]]
-  digest = "1:d707dbc1330c0ed177d4642d6ae102d5e2c847ebd0eb84562d0dc4f024531cfc"
+  digest = "1:3e39bafd6c2f4bf3c76c3bfd16a2e09e016510ad5db90dc02b88e2f565d6d595"
   name = "github.com/spf13/afero"
   packages = [
     ".",
     "mem",
   ]
   pruneopts = "UT"
-  revision = "a5d6946387efe7d64d09dcba68cdd523dc1273a3"
-  version = "v1.2.0"
+  revision = "f4711e4db9e9a1d3887343acb72b2bbfc2f686f5"
+  version = "v1.2.1"
 
 [[projects]]
   digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
@@ -530,7 +520,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:685fdfea42d825ebd39ee0994354b46c374cf2c2b2d97a41a8dee1807c6a9b62"
+  digest = "1:b96cee7ae2088198a9887fd14af90102f8cd33fb3d55a900facde4214b1e0bb3"
   name = "github.com/syndtr/goleveldb"
   packages = [
     "leveldb",
@@ -547,7 +537,7 @@
     "leveldb/util",
   ]
   pruneopts = "UT"
-  revision = "b001fa50d6b27f3f0bb175a87d0cb55426d0a0ae"
+  revision = "4217c9f31f5816db02addc94e56061da77f288d8"
 
 [[projects]]
   digest = "1:605b6546f3f43745695298ec2d342d3e952b6d91cdf9f349bea9315f677d759f"
@@ -555,6 +545,7 @@
   packages = ["btcec"]
   pruneopts = "UT"
   revision = "e5840949ff4fff0c56f9b6a541e22b63581ea9df"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:ad9c4c1a4e7875330b1f62906f2830f043a23edb5db997e3a5ac5d3e6eadf80a"
@@ -565,20 +556,19 @@
   version = "v0.14.1"
 
 [[projects]]
-  digest = "1:1bb088f6291e5426e3874a60bca0e481a91a5633395d7e0c427ec3e49b626e7b"
+  digest = "1:e1cc8dd891e64aab63b0c09f2f12456cbe2cd9cbd9d96dfae3281245f05c2428"
   name = "github.com/tendermint/iavl"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ac7c35c12e8633a1e9fd0b52a00b900b40f32cd3"
-  version = "v0.12.1"
+  revision = "de0740903a67b624d887f9055d4c60175dcfa758"
+  version = "v0.12.0"
 
 [[projects]]
-  digest = "1:4a372b718ee1433fa421e1c9e450a8b14bc24f2b5d7b5f9329d4d49e360f5f9e"
+  digest = "1:fbf8a69c035430a7f06fe0b725ef9ef1ea02366a35d35a0f4c2c2c77b5d1d9cb"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
     "abci/example/code",
-    "abci/example/counter",
     "abci/example/kvstore",
     "abci/server",
     "abci/types",
@@ -639,8 +629,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "e0f8936455029a40287a69d5b0e7baa4d5864da1"
-  version = "v0.30.1"
+  revision = "1e1ca15bccedc16c2452c73745c3c2b5df91ae96"
+  version = "v0.27.4"
 
 [[projects]]
   digest = "1:5a736f4722932d9a45d28852e85b83f68292d9af2ef0be29d4e5fe6fd89d5d96"
@@ -667,7 +657,7 @@
   version = "v0.8.0"
 
 [[projects]]
-  digest = "1:a454511f589cc0cf4e4027920a2924cc70b45a51ae07d6dee38c5bdb0fdc1d86"
+  digest = "1:9ee7b5b1fdcf6dcb0d609912076bb8da0c1c953a55141c7d83fa21dee29ad4f2"
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
@@ -688,7 +678,6 @@
     "ripemd160",
     "salsa20/salsa",
     "scrypt",
-    "sha3",
   ]
   pruneopts = "UT"
   revision = "3764759f34a542a3aef74d6b02e35be7ab893bba"
@@ -713,14 +702,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:40efb75e7c2681e4fb5d886930a7074d0c2918334ea0e62a0fc8661245d9a7c8"
+  digest = "1:ad5e62a015226e008f9ca24cdf00d65c74f004f1b247cfa033ca9e3afcf41b29"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
   ]
   pruneopts = "UT"
-  revision = "9a3f9b0469bbc6b8802087ae5c0af9f61502de01"
+  revision = "cc5685c2db1239775905f3911f0067c0fa74762f"
 
 [[projects]]
   digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
@@ -751,10 +740,10 @@
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
   pruneopts = "UT"
-  revision = "bd9b4fb69e2ffd37621a6caa54dcbead29b546f2"
+  revision = "082222b4a5c572e33e82ee9162d1352c7cf38682"
 
 [[projects]]
-  digest = "1:9edd250a3c46675d0679d87540b30c9ed253b19bd1fd1af08f4f5fb3c79fc487"
+  digest = "1:9ab5a33d8cb5c120602a34d2e985ce17956a4e8c2edce7e6961568f95e40c09a"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -790,8 +779,8 @@
     "tap",
   ]
   pruneopts = "UT"
-  revision = "df014850f6dee74ba2fc94874043a9f3f75fbfd8"
-  version = "v1.17.0"
+  revision = "a02b0774206b209466313a0b525d2c738fe407eb"
+  version = "v1.18.0"
 
 [[projects]]
   branch = "v2"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -545,7 +545,6 @@
   packages = ["btcec"]
   pruneopts = "UT"
   revision = "e5840949ff4fff0c56f9b6a541e22b63581ea9df"
-  version = "v0.1.0"
 
 [[projects]]
   digest = "1:ad9c4c1a4e7875330b1f62906f2830f043a23edb5db997e3a5ac5d3e6eadf80a"
@@ -564,11 +563,12 @@
   version = "v0.12.0"
 
 [[projects]]
-  digest = "1:fbf8a69c035430a7f06fe0b725ef9ef1ea02366a35d35a0f4c2c2c77b5d1d9cb"
+  digest = "1:27a000a63afee3f22591adc0b6be56be4f850f0af5e85e7673a4dfbab0ab5a87"
   name = "github.com/tendermint/tendermint"
   packages = [
     "abci/client",
     "abci/example/code",
+    "abci/example/counter",
     "abci/example/kvstore",
     "abci/server",
     "abci/types",
@@ -629,8 +629,8 @@
     "version",
   ]
   pruneopts = "UT"
-  revision = "1e1ca15bccedc16c2452c73745c3c2b5df91ae96"
-  version = "v0.27.4"
+  revision = "aa40cfcbb97fac3832b47ccdcf99c6b7fb504cb2"
+  version = "v0.28.0"
 
 [[projects]]
   digest = "1:5a736f4722932d9a45d28852e85b83f68292d9af2ef0be29d4e5fe6fd89d5d96"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,22 +2,6 @@
 
 
 [[projects]]
-  digest = "1:7736fc6da04620727f8f3aa2ced8d77be8e074a302820937aa5993848c769b27"
-  name = "github.com/ZondaX/hid-go"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "48b08affede2cea076a3cf13b2e3f72ed262b743"
-  version = "v0.4.0"
-
-[[projects]]
-  digest = "1:1ba351898f7efc68c7c9ff3145b920e478f716b077fdaaf06b967c5d883fa988"
-  name = "github.com/ZondaX/ledger-go"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "c3225ab10c2f53397d4aa419a588466493572b22"
-  version = "v0.4.0"
-
-[[projects]]
   digest = "1:1156cfea0ff969858f6027df95c15ca5e802556b466aebeedaf53dde3b301db3"
   name = "github.com/allegro/bigcache"
   packages = [
@@ -61,12 +45,11 @@
   version = "v0.1.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:093bf93a65962e8191e3e8cd8fc6c363f83d43caca9739c906531ba7210a9904"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
   pruneopts = "UT"
-  revision = "7d2daa5bfef28c5e282571bc06416516936115ee"
+  revision = "ed77733ec07dfc8a513741138419b8d9d3de9d2d"
 
 [[projects]]
   digest = "1:386de157f7d19259a7f9c81f26ce011223ce0f090353c1152ffdf730d7d10ac2"
@@ -76,7 +59,7 @@
   revision = "d4cc87b860166d00d6b5b9e0d3b3d71d6088d4d4"
 
 [[projects]]
-  digest = "1:52701d2502a7dd2fa48d958c2c24a9ae48f5c2c68e14c68ae74561a517c9537a"
+  digest = "1:a90fdbbff9e7bbfad76666c35534b7534dd73ebecb9c7daa82fe2de68afbaa4b"
   name = "github.com/cosmos/cosmos-sdk"
   packages = [
     "baseapp",
@@ -95,7 +78,20 @@
     "server",
     "server/config",
     "store",
+    "store/cachekv",
+    "store/cachemulti",
+    "store/dbadapter",
+    "store/errors",
+    "store/gaskv",
+    "store/iavl",
+    "store/prefix",
+    "store/rootmulti",
+    "store/tracekv",
+    "store/transient",
+    "store/types",
+    "tests",
     "types",
+    "types/rest",
     "version",
     "x/auth",
     "x/auth/client/txbuilder",
@@ -114,17 +110,18 @@
     "x/params",
     "x/params/subspace",
     "x/slashing",
-    "x/stake",
-    "x/stake/client/cli",
-    "x/stake/keeper",
-    "x/stake/querier",
-    "x/stake/simulation",
-    "x/stake/tags",
-    "x/stake/types",
+    "x/slashing/tags",
+    "x/staking",
+    "x/staking/client/cli",
+    "x/staking/keeper",
+    "x/staking/querier",
+    "x/staking/simulation",
+    "x/staking/tags",
+    "x/staking/types",
   ]
   pruneopts = "UT"
-  revision = "2b3842c58305a4e26d457d3d3bd6cf849ffddcdd"
-  version = "v0.29.0"
+  revision = "906e9509cfcae3330584416c8b8e9cfe6c8d2766"
+  version = "v0.32.0"
 
 [[projects]]
   digest = "1:e8a3550c8786316675ff54ad6f09d265d129c9d986919af7f541afba50d87ce2"
@@ -646,12 +643,28 @@
   version = "v0.27.4"
 
 [[projects]]
-  digest = "1:a7485b2a69f996923f9d3406a9a853fd8eb31818515e985a830d71f88f6a925b"
+  digest = "1:5a736f4722932d9a45d28852e85b83f68292d9af2ef0be29d4e5fe6fd89d5d96"
+  name = "github.com/zondax/hid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "302fd402163c34626286195dfa9adac758334acc"
+  version = "v0.9.0"
+
+[[projects]]
+  digest = "1:fca24169988a61ea725d1326de30910d8049fe68bcbc194d28803f9a76dda380"
   name = "github.com/zondax/ledger-cosmos-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d4aed6d929a703bb555a2d79fe9c470afe61f648"
-  version = "v0.9.2"
+  revision = "69fdb8ce5e5b9d9c3b22b9248e117b231d4f06dd"
+  version = "v0.9.7"
+
+[[projects]]
+  digest = "1:f8e4c0b959174a1fa5946b12f1f2ac7ea5651bef20a9e4a8dac55dbffcaa6cd6"
+  name = "github.com/zondax/ledger-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "69c15f1333a9b6866e5f66096561c7d138894bc5"
+  version = "v0.8.0"
 
 [[projects]]
   digest = "1:9ee7b5b1fdcf6dcb0d609912076bb8da0c1c953a55141c7d83fa21dee29ad4f2"
@@ -799,7 +812,6 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/bgentry/speakeasy",
     "github.com/cosmos/cosmos-sdk/baseapp",
     "github.com/cosmos/cosmos-sdk/client",
     "github.com/cosmos/cosmos-sdk/client/context",
@@ -820,7 +832,6 @@
     "github.com/ethereum/go-ethereum/event",
     "github.com/ethereum/go-ethereum/rlp",
     "github.com/ethereum/go-ethereum/rpc",
-    "github.com/mattn/go-isatty",
     "github.com/spf13/cobra",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/require",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,11 +27,11 @@
 
 [[constraint]]
   name = "github.com/cosmos/cosmos-sdk"
-  version = "0.32.0"
+  version = "v0.32.0"
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  version = "<1.8.20"
+  version = "<=1.8.20"
 
    # Can be removed when https://github.com/golang/dep/issues/1847 is resolved 
    [[prune.project]]
@@ -62,9 +62,13 @@
   name = "github.com/tendermint/go-amino"
   version = "0.14.1"
 
-[[constraint]]
+[[override]]
+  name = "github.com/tendermint/iavl"
+  version = "~v0.12.0"
+
+[[override]]
   name = "github.com/tendermint/tendermint"
-  version = "0.27.4"
+  version = "=0.28.0"
 
 [[override]]
   name = "golang.org/x/crypto"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/cosmos/cosmos-sdk"
-  version = "0.29.0"
+  version = "0.32.0"
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  version = "1.8.21"
+  version = "<1.8.20"
 
    # Can be removed when https://github.com/golang/dep/issues/1847 is resolved 
    [[prune.project]]
@@ -64,7 +64,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
-  version = "0.30.1"
+  version = "0.27.4"
 
 [[override]]
   name = "golang.org/x/crypto"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,20 +26,17 @@
 
 
 [[constraint]]
-  name = "github.com/bgentry/speakeasy"
-  version = "0.1.0"
-
-[[constraint]]
   name = "github.com/cosmos/cosmos-sdk"
   version = "0.32.0"
 
 [[constraint]]
   name = "github.com/ethereum/go-ethereum"
-  version = "1.8.20"
+  version = "1.8.21"
 
-[[constraint]]
-  name = "github.com/mattn/go-isatty"
-  version = "0.0.4"
+   # Can be removed when https://github.com/golang/dep/issues/1847 is resolved 
+   [[prune.project]]
+    name = "github.com/ethereum/go-ethereum"
+    unused-packages = false
 
 [[constraint]]
   name = "github.com/pkg/errors"
@@ -67,7 +64,7 @@
 
 [[constraint]]
   name = "github.com/tendermint/tendermint"
-  version = "0.27.4"
+  version = "0.30.1"
 
 [[override]]
   name = "golang.org/x/crypto"

--- a/README.md
+++ b/README.md
@@ -43,28 +43,6 @@ Plasma Light Client:
 Use `plasmacli` to run any of the commands for this light client
 
 The light client uses the Ethereum keystore to create and store passphrase encrypted keys in `$HOME/.plasmacli/keys/`
-
-### dep ensure 
-When building the sidechain, go dep is used to manage dependencies. 
-Running `dep ensure` followed by `go build` will result in the following output:
-
-```
-# github.com/FourthState/plasma-mvp-sidechain/vendor/github.com/ethereum/go-ethereum/crypto/secp256k1
-../vendor/github.com/ethereum/go-ethereum/crypto/secp256k1/curve.go:42:44: fatal error: libsecp256k1/include/secp256k1.h: No such file or directory
-```
-This is caused by a go dep issue outlined [here](https://github.com/tools/godep/issues/422).
-To fix this locally, add the following in Gopkg.lock under `crypto/secp256k1` and above `crypto/sha3`:
-
-```
-"crypto/secp256k1/libsecp256k1",
-"crypto/secp256k1/libsecp256k1/include",
-"crypto/secp256k1/libsecp256k1/src",
-"crypto/secp256k1/libsecp256k1/src/modules/recovery",
-```
-
-Run `dep ensure -vendor-only`
-
-Your vendor folder should now contain all the necessary dependencies, there is no need to run `dep ensure` again. 
   
 ### Plasma Architecture 
 See our [research repository](https://github.com/FourthState/plasma-research) for architectural explanations of our Plasma implementation. 

--- a/client/plasmacli/keys/add.go
+++ b/client/plasmacli/keys/add.go
@@ -2,7 +2,7 @@ package keys
 
 import (
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +18,7 @@ var addCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		address, err := ks.Add(name)
+		address, err := store.AddAccount(name)
 		if err != nil {
 			return err
 		}

--- a/client/plasmacli/keys/delete.go
+++ b/client/plasmacli/keys/delete.go
@@ -2,7 +2,7 @@ package keys
 
 import (
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +18,7 @@ var deleteCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
-		if err := ks.Delete(name); err != nil {
+		if err := store.DeleteAccount(name); err != nil {
 			return err
 		}
 

--- a/client/plasmacli/keys/import.go
+++ b/client/plasmacli/keys/import.go
@@ -4,7 +4,7 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -61,7 +61,7 @@ You must remember this passphrase to unlock your account in the future.
 
 		}
 
-		address, err := ks.ImportECDSA(name, key)
+		address, err := store.ImportECDSA(name, key)
 		if err != nil {
 			return err
 		}

--- a/client/plasmacli/keys/list.go
+++ b/client/plasmacli/keys/list.go
@@ -3,7 +3,7 @@ package keys
 import (
 	"errors"
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,7 @@ var listCmd = &cobra.Command{
 	Long:  "Return a list of all account addresses stored by the local keystore",
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		iter, db := ks.AccountIterator()
+		iter, db := store.AccountIterator()
 		if iter == nil || db == nil {
 			return errors.New("unexpected error encountered when opening account data")
 		}

--- a/client/plasmacli/keys/main.go
+++ b/client/plasmacli/keys/main.go
@@ -1,7 +1,7 @@
 package keys
 
 import (
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +12,6 @@ var keysCmd = &cobra.Command{
 }
 
 func KeysCmd() *cobra.Command {
-	ks.InitKeystore()
+	store.InitKeystore()
 	return keysCmd
 }

--- a/client/plasmacli/keys/update.go
+++ b/client/plasmacli/keys/update.go
@@ -1,7 +1,7 @@
 package keys
 
 import (
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -31,7 +31,7 @@ Usage:
 		name := args[0]
 
 		updatedName := viper.GetString(nameF)
-		if err := ks.Update(name, updatedName); err != nil {
+		if err := store.UpdateAccount(name, updatedName); err != nil {
 			return err
 		}
 

--- a/client/plasmacli/keys/update.go
+++ b/client/plasmacli/keys/update.go
@@ -31,10 +31,12 @@ Usage:
 		name := args[0]
 
 		updatedName := viper.GetString(nameF)
-		if err := store.UpdateAccount(name, updatedName); err != nil {
+		msg, err := store.UpdateAccount(name, updatedName)
+		if err != nil {
 			return err
 		}
 
+		fmt.Println(msg)
 		return nil
 	},
 }

--- a/client/plasmacli/keys/update.go
+++ b/client/plasmacli/keys/update.go
@@ -1,6 +1,7 @@
 package keys
 
 import (
+	"fmt"
 	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/client/plasmacli/main.go
+++ b/client/plasmacli/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
 	"github.com/FourthState/plasma-mvp-sidechain/client/plasmacli/keys"
 	"github.com/FourthState/plasma-mvp-sidechain/client/plasmacli/query"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -46,7 +46,7 @@ func init() {
 	// initConfig to be ran when Execute is called
 	cobra.OnInitialize(initConfig)
 	rootCmd.Flags().String(client.FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
-	rootCmd.PersistentFlags().StringP(ks.DirFlag, "d", homeDir, "directory for plasmacli")
+	rootCmd.PersistentFlags().StringP(store.DirFlag, "d", homeDir, "directory for plasmacli")
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		fmt.Println(err)
 	}

--- a/client/plasmacli/prove.go
+++ b/client/plasmacli/prove.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	clistore "github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/FourthState/plasma-mvp-sidechain/store"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -23,7 +23,7 @@ var proveCmd = &cobra.Command{
 		ctx := context.NewCLIContext().WithTrustNode(true)
 		name := args[0]
 
-		addr, err := ks.Get(name)
+		addr, err := clistore.GetAccount(name)
 		if err != nil {
 			return err
 		}

--- a/client/plasmacli/query/account.go
+++ b/client/plasmacli/query/account.go
@@ -2,7 +2,7 @@ package query
 
 import (
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	ks "github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/FourthState/plasma-mvp-sidechain/store"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -24,7 +24,7 @@ var balanceCmd = &cobra.Command{
 		ctx := context.NewCLIContext().WithCodec(codec.New()).WithTrustNode(true)
 		name := args[0]
 
-		addr, err := ks.Get(name)
+		addr, err := ks.GetAccount(name)
 		if err != nil {
 			return err
 		}

--- a/client/plasmacli/sign.go
+++ b/client/plasmacli/sign.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	clistore "github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/FourthState/plasma-mvp-sidechain/store"
 	"github.com/FourthState/plasma-mvp-sidechain/utils"
@@ -56,8 +56,12 @@ var signCmd = &cobra.Command{
 
 		// create the signature
 		hash := utils.ToEthSignedMessageHash(utxo.ConfirmationHash)
-		sig, err := ks.SignHashWithPassphrase(name, hash)
+		sig, err := clistore.SignHashWithPassphrase(name, hash)
 		if err != nil {
+			return err
+		}
+
+		if err := clistore.SaveSig(position, sig); err != nil {
 			return err
 		}
 

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -208,7 +208,7 @@ plasmacli <to> <amount>  -a <account>,<account> -in <amount>,<amount>`,
 			if err != nil {
 				return err
 			}
-			fmt.Printf("Committed at block %d. Hash %s\n", res.Height, res.Hash.String())
+			fmt.Printf("Committed at block %d. Hash 0x%x\n", res.Height, res.TxHash)
 		} else {
 			if _, err := ctx.BroadcastTxAsync(txBytes); err != nil {
 				return err

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
-	ks "github.com/FourthState/plasma-mvp-sidechain/client/keystore"
+	"github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/FourthState/plasma-mvp-sidechain/msgs"
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/FourthState/plasma-mvp-sidechain/utils"
@@ -171,7 +171,7 @@ plasmacli <to> <amount>  -a <account>,<account> -in <amount>,<amount>`,
 		signer := accs[0]
 		txHash := utils.ToEthSignedMessageHash(tx.TxHash())
 		var signature [65]byte
-		sig, err := ks.SignHashWithPassphrase(signer, txHash)
+		sig, err := store.SignHashWithPassphrase(signer, txHash)
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ plasmacli <to> <amount>  -a <account>,<account> -in <amount>,<amount>`,
 			if len(accs) > 2 {
 				signer = accs[1]
 			}
-			sig, err := ks.SignHashWithPassphrase(signer, txHash)
+			sig, err := store.SignHashWithPassphrase(signer, txHash)
 			if err != nil {
 				return err
 			}

--- a/client/store/keystore.go
+++ b/client/store/keystore.go
@@ -4,9 +4,6 @@ import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-
 	cosmoscli "github.com/cosmos/cosmos-sdk/client"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -14,6 +11,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"os"
+	"path/filepath"
 )
 
 const (

--- a/client/store/keystore.go
+++ b/client/store/keystore.go
@@ -1,9 +1,12 @@
-package keystore
+package store
 
 import (
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/bgentry/speakeasy"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -13,8 +16,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
-	"os"
-	"path/filepath"
 )
 
 const (
@@ -25,7 +26,7 @@ const (
 
 	PassphrasePrompt = "Enter passphrase:"
 
-	accountDir = "accounts.ldb"
+	accountDir = "data/accounts.ldb"
 	keysDir    = "keys"
 
 	DirFlag = "directory"
@@ -56,7 +57,7 @@ func AccountIterator() (iterator.Iterator, *leveldb.DB) {
 
 // Add a new account to the keystore
 // Add account name and address to leveldb
-func Add(name string) (ethcmn.Address, error) {
+func AddAccount(name string) (ethcmn.Address, error) {
 	dir := getDir(accountDir)
 	db, err := leveldb.OpenFile(dir, nil)
 	if err != nil {
@@ -87,7 +88,7 @@ func Add(name string) (ethcmn.Address, error) {
 }
 
 // Retrieve the address of an account
-func Get(name string) (ethcmn.Address, error) {
+func GetAccount(name string) (ethcmn.Address, error) {
 	dir := getDir(accountDir)
 	db, err := leveldb.OpenFile(dir, nil)
 	if err != nil {
@@ -105,7 +106,7 @@ func Get(name string) (ethcmn.Address, error) {
 
 // Remove an account from the local keystore
 // and the leveldb
-func Delete(name string) error {
+func DeleteAccount(name string) error {
 	dir := getDir(accountDir)
 	db, err := leveldb.OpenFile(dir, nil)
 	if err != nil {
@@ -132,7 +133,7 @@ func Delete(name string) error {
 
 // Update either the name of an account
 // or the passphrase for an account
-func Update(name string, updatedName string) error {
+func UpdateAccount(name string, updatedName string) error {
 	dir := getDir(accountDir)
 	db, err := leveldb.OpenFile(dir, nil)
 	if err != nil {
@@ -210,7 +211,7 @@ func ImportECDSA(name string, pk *ecdsa.PrivateKey) (ethcmn.Address, error) {
 }
 
 func SignHashWithPassphrase(signer string, hash []byte) ([]byte, error) {
-	addr, err := Get(signer)
+	addr, err := GetAccount(signer)
 	if err != nil {
 		return nil, err
 	}

--- a/client/store/keystore_test.go
+++ b/client/store/keystore_test.go
@@ -7,25 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	cosmoscli "github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
-
-var currentStdin *bufio.Reader
-
-func init() {
-	currentStdin = bufio.NewReader(os.Stdin)
-}
-
-// overrideStdin allows to temporarily override stdin
-func overrideStdin(newStdin *bufio.Reader) (cleanUp func()) {
-	prevStdin := currentStdin
-	currentStdin = newStdin
-	cleanUp = func() {
-		currentStdin = prevStdin
-	}
-	return cleanUp
-}
 
 // Add, Delete, Update and iterate through accounts
 func TestAccounts(t *testing.T) {
@@ -49,7 +34,7 @@ func TestAccounts(t *testing.T) {
 	}
 
 	for i, n := range cases {
-		cleanUp := overrideStdin(bufio.NewReader(strings.NewReader("test1234\ntest1234\n")))
+		cleanUp := cosmoscli.OverrideStdin(bufio.NewReader(strings.NewReader("test1234\ntest1234\n")))
 		defer cleanUp()
 		_, err := AddAccount(n)
 		require.NoErrorf(t, err, "case %d: failed to add account %s", i, n)

--- a/client/store/keystore_test.go
+++ b/client/store/keystore_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"bufio"
+	//	"math/big"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+var currentStdin *bufio.Reader
+
+func init() {
+	currentStdin = bufio.NewReader(os.Stdin)
+}
+
+// overrideStdin allows to temporarily override stdin
+func overrideStdin(newStdin *bufio.Reader) (cleanUp func()) {
+	prevStdin := currentStdin
+	currentStdin = newStdin
+	cleanUp = func() {
+		currentStdin = prevStdin
+	}
+	return cleanUp
+}
+
+// Add, Delete, Update and iterate through accounts
+func TestAccounts(t *testing.T) {
+	// setup testing env
+	os.Mkdir("testing", os.ModePerm)
+	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+
+	// cleanup
+	defer func() {
+		viper.Reset()
+		os.RemoveAll("testing")
+	}()
+
+	InitKeystore()
+
+	cases := []string{
+		"mykey",
+		"another-key",
+		"!aADS_AS@#$%^&*()",
+		"    last     key",
+	}
+
+	for i, n := range cases {
+		cleanUp := overrideStdin(bufio.NewReader(strings.NewReader("test1234\ntest1234\n")))
+		defer cleanUp()
+		_, err := AddAccount(n)
+		require.NoErrorf(t, err, "case %d: failed to add account %s", i, n)
+	}
+
+}

--- a/client/store/keystore_test.go
+++ b/client/store/keystore_test.go
@@ -2,12 +2,12 @@ package store
 
 import (
 	"bufio"
-	//	"math/big"
 	"os"
 	"strings"
 	"testing"
 
 	cosmoscli "github.com/cosmos/cosmos-sdk/client"
+	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
@@ -33,11 +33,63 @@ func TestAccounts(t *testing.T) {
 		"    last     key",
 	}
 
+	// Check adding and getting accounts
 	for i, n := range cases {
 		cleanUp := cosmoscli.OverrideStdin(bufio.NewReader(strings.NewReader("test1234\ntest1234\n")))
 		defer cleanUp()
-		_, err := AddAccount(n)
-		require.NoErrorf(t, err, "case %d: failed to add account %s", i, n)
+		addr1, err := AddAccount(n)
+		require.NoErrorf(t, err, "case %d: failed to add account { %s }", i, n)
+
+		addr2, err := GetAccount(n)
+		require.NoError(t, err, "case %d: failed to get account { %s }", i, n)
+		require.Equal(t, addr1, addr2, "case %d: address added and retrieved not equal for account { %s }", i, n)
 	}
 
+	// Check that iterator matches
+	iter, db := AccountIterator()
+	i := 0
+	var actualNames []string
+	var actualAddrs []ethcmn.Address
+	for iter.Next() {
+		actualNames = append(actualNames, string(iter.Key()))
+		actualAddrs = append(actualAddrs, ethcmn.BytesToAddress(iter.Value()))
+		i++
+	}
+	iter.Release()
+	db.Close()
+
+	for i, n := range actualNames {
+		expectedAddr, err := GetAccount(string(n))
+		require.NoError(t, err, "case %d: failed to get account { %s }", i, n)
+		require.Equal(t, actualAddrs[i], expectedAddr, "case %d: address returned from iterator does not match actual address for account { %s }", i, n)
+		i++
+	}
+
+	updatedNames := []string{
+		"key",
+		"k",
+		"sdfghjk",
+		"plasma",
+	}
+
+	// Update Account name and password then Delete Accounts
+	for i, n := range cases {
+		_, err := UpdateAccount(cases[i], updatedNames[i])
+		require.NoError(t, err, "case %d: failed to update account name { %s }", i, n)
+
+		_, err = GetAccount(cases[i])
+		require.Error(t, err, "case %d: retireved account for mapping that should not exist, account { %s }", i, n)
+		_, err = GetAccount(updatedNames[i])
+		require.NoError(t, err, "case %d: failed to retrieve account after updating, account { %s }", i, updatedNames[i])
+
+		cleanUp := cosmoscli.OverrideStdin(bufio.NewReader(strings.NewReader("test1234\nnewpass1234\n")))
+		defer cleanUp()
+		_, err = UpdateAccount(updatedNames[i], "")
+		require.NoError(t, err, "case %d: failed to update account passphrase for account { %s }", i, updatedNames[i])
+
+		cleanUp = cosmoscli.OverrideStdin(bufio.NewReader(strings.NewReader("newpass1234\n")))
+		defer cleanUp()
+		err = DeleteAccount(updatedNames[i])
+		require.NoError(t, err, "case %d: failed to delete account { %s }", i, updatedNames[i])
+	}
 }

--- a/client/store/keystore_test.go
+++ b/client/store/keystore_test.go
@@ -2,14 +2,13 @@ package store
 
 import (
 	"bufio"
-	"os"
-	"strings"
-	"testing"
-
 	cosmoscli "github.com/cosmos/cosmos-sdk/client"
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"os"
+	"strings"
+	"testing"
 )
 
 // Add, Delete, Update and iterate through accounts

--- a/client/store/sigs.go
+++ b/client/store/sigs.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"fmt"
+
+	"github.com/FourthState/plasma-mvp-sidechain/plasma"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+const (
+	signatureDir = "data/signatures.ldb"
+)
+
+// Saves confirmation signature
+// Overrides any value previously set at the given position
+func SaveSig(position plasma.Position, sig []byte) error {
+	dir := getDir(signatureDir)
+	db, err := leveldb.OpenFile(dir, nil)
+	if err != nil {
+		return fmt.Errorf("failed to open db for signatures: { %s }", err)
+	}
+	defer db.Close()
+
+	k := getSigKey(position)
+	if err := db.Put(k, sig, nil); err != nil {
+		return fmt.Errorf("failed to save confirmation signature: { %s }", err)
+	}
+
+	return nil
+}
+
+// Retrieves confirmation signautres
+func GetSig(position plasma.Position) ([]byte, error) {
+	dir := getDir(signatureDir)
+	db, err := leveldb.OpenFile(dir, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open db for signature: { %s }", err)
+	}
+	defer db.Close()
+
+	k := getSigKey(position)
+	if sig, err := db.Get(k, nil); err != nil {
+		return nil, fmt.Errorf("failed to get signature: { %s }", err)
+	} else {
+		return sig, nil
+	}
+}
+
+// return key used for confirm signature mapping
+func getSigKey(pos plasma.Position) []byte {
+	return append(pos.BlockNum.Bytes(), []byte(string(pos.TxIndex))...)
+}

--- a/client/store/sigs.go
+++ b/client/store/sigs.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"fmt"
-
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/syndtr/goleveldb/leveldb"
 )

--- a/client/store/sigs_test.go
+++ b/client/store/sigs_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/FourthState/plasma-mvp-sidechain/plasma"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSavSig(t *testing.T) {
+	// setup testing env
+	os.Mkdir("testing", os.ModePerm)
+	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+
+	// cleanup
+	defer func() {
+		viper.Reset()
+		os.RemoveAll("testing")
+
+	}()
+
+	cases := [][]int64{
+		// must save for both output indicies
+		{5, 0, 0, 0},
+		// deposit
+		{0, 0, 0, 10},
+		// different txindex
+		{5, 1, 0, 0},
+		// different blk num
+		{6, 1, 0, 0},
+	}
+
+	for _, p := range cases {
+		key, _ := crypto.GenerateKey()
+		txHash := crypto.Keccak256([]byte("txhash"))
+
+		expected, err := crypto.Sign(txHash, key)
+		pos := plasma.NewPosition(big.NewInt(p[0]), uint16(p[1]), uint8(p[2]), big.NewInt(p[3]))
+
+		_, err = GetSig(pos)
+		require.Error(t, err, "")
+
+		err = SaveSig(pos, expected)
+		require.NoError(t, err, "")
+
+		actual, err := GetSig(pos)
+		require.NoError(t, err, "")
+		require.Equal(t, expected, actual, "")
+
+		if !pos.IsDeposit() {
+			// changing output index should not effect
+			// retrieval of signature
+			pos.OutputIndex = uint8(1)
+			actual, err = GetSig(pos)
+
+			require.NoError(t, err, "")
+			require.Equal(t, expected, actual, "")
+		}
+	}
+}

--- a/client/store/sigs_test.go
+++ b/client/store/sigs_test.go
@@ -1,14 +1,13 @@
 package store
 
 import (
-	"math/big"
-	"os"
-	"testing"
-
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"math/big"
+	"os"
+	"testing"
 )
 
 func TestSavSig(t *testing.T) {

--- a/client/store/sigs_test.go
+++ b/client/store/sigs_test.go
@@ -34,7 +34,7 @@ func TestSavSig(t *testing.T) {
 		{6, 1, 0, 0},
 	}
 
-	for _, p := range cases {
+	for i, p := range cases {
 		key, _ := crypto.GenerateKey()
 		txHash := crypto.Keccak256([]byte("txhash"))
 
@@ -42,14 +42,14 @@ func TestSavSig(t *testing.T) {
 		pos := plasma.NewPosition(big.NewInt(p[0]), uint16(p[1]), uint8(p[2]), big.NewInt(p[3]))
 
 		_, err = GetSig(pos)
-		require.Error(t, err, "")
+		require.Errorf(t, err, "case %d: did not error when getting non existent signature for position %s", i, pos)
 
 		err = SaveSig(pos, expected)
-		require.NoError(t, err, "")
+		require.NoError(t, err, "case %d: failed to save signature for position %s", i, pos)
 
 		actual, err := GetSig(pos)
-		require.NoError(t, err, "")
-		require.Equal(t, expected, actual, "")
+		require.NoError(t, err, "case %d: failed when getting signature for position %s", i, pos)
+		require.Equal(t, expected, actual, "case %d: actual signature was not equal to expected signature for position %s", i, pos)
 
 		if !pos.IsDeposit() {
 			// changing output index should not effect
@@ -57,8 +57,8 @@ func TestSavSig(t *testing.T) {
 			pos.OutputIndex = uint8(1)
 			actual, err = GetSig(pos)
 
-			require.NoError(t, err, "")
-			require.Equal(t, expected, actual, "")
+			require.NoError(t, err, "case %d: failed when getting signature for position %s", i, pos)
+			require.Equal(t, expected, actual, "case %d: actual signature was not equal to expected signature for position %s", i, pos)
 		}
 	}
 }

--- a/server/plasmad/main.go
+++ b/server/plasmad/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"github.com/FourthState/plasma-mvp-sidechain/server/app"
 	"github.com/FourthState/plasma-mvp-sidechain/server/plasmad/cmd"
 	"github.com/FourthState/plasma-mvp-sidechain/server/plasmad/config"
@@ -12,7 +11,6 @@ import (
 	"github.com/tendermint/tendermint/libs/cli"
 	dbm "github.com/tendermint/tendermint/libs/db"
 	"github.com/tendermint/tendermint/libs/log"
-	tmtypes "github.com/tendermint/tendermint/types"
 	"io"
 	"os"
 	"path/filepath"
@@ -29,7 +27,7 @@ func main() {
 		PersistentPreRunE: persistentPreRunEFn(ctx),
 	}
 	rootCmd.AddCommand(cmd.InitCmd(ctx, cdc))
-	server.AddCommands(ctx, cdc, rootCmd, newApp, exportAppState)
+	server.AddCommands(ctx, cdc, rootCmd, newApp, nil)
 
 	// HomeFlag in tendermint cli will be set to `~/.plasmad`
 	rootDir := os.ExpandEnv("$HOME/.plasmad")
@@ -74,10 +72,4 @@ func newApp(logger log.Logger, db dbm.DB, traceStore io.Writer) abci.Application
 	return app.NewPlasmaMVPChain(logger, db, traceStore,
 		app.SetPlasmaOptionsFromConfig(plasmaConfig),
 	)
-}
-
-// non-functional
-func exportAppState(logger log.Logger, db dbm.DB, traceStore io.Writer, _ int64, _ bool) (json.RawMessage, []tmtypes.GenesisValidator, error) {
-	papp := app.NewPlasmaMVPChain(logger, db, traceStore)
-	return papp.ExportAppStateJSON()
 }


### PR DESCRIPTION
Client side storage of confirmation signatures. 

Opening as pr to my own branch since it is easier to review that way. I changed keystore directory to store and add a sigs.go file for storing confirm sigs. I am not sure if it would be better to move client/store dir into our store/ dir, since one is for application storage and the other is for client storage. 

.plasmacli will now have: data/, keys/, plasma.toml
data/ has accounts.ldb and signatures.ldb

You might need to rm your current .plasmacli directory before installing this branch

Upgrade to sdk 0.32.0