### PR TITLE
Colin/scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 ### Added
+- [\#126](https://github.com/FourthState/plasma-mvp-sidechain/pull/126) Added installation script
 - **plasmacli:** [\#110](https://github.com/FourthState/plasma-mvp-sidechain/pull/110) Added eth subcommand for rootchain interaction
 - **plasmacli:** [\#110](https://github.com/FourthState/plasma-mvp-sidechain/pull/110) Added plasma.toml in .plasmacli/ for rootchain connection configuration
 - **plasmacli:** [\#108](https://github.com/FourthState/plasma-mvp-sidechain/pull/108) Added keys subcommand with account mapping

--- a/client/config.go
+++ b/client/config.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/spf13/viper"
 	cmn "github.com/tendermint/tendermint/libs/common"
+	"path/filepath"
 	"text/template"
 )
 
@@ -54,6 +56,10 @@ func WritePlasmaConfigFile(configFilePath string, config PlasmaConfig) {
 
 	if err := configTemplate.Execute(&buffer, &config); err != nil {
 		panic(err)
+	}
+
+	if err := cmn.EnsureDir(filepath.Dir(configFilePath), 0600); err != nil {
+		fmt.Printf("ERROR: failed to create directory: %s, recieved error: { %s }", filepath.Dir(configFilePath), err)
 	}
 
 	// 0600 for owner only read+write permissions

--- a/scripts/plasma_install.sh
+++ b/scripts/plasma_install.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# This script is intended to install geth, plasmad, and plasmacli
+# It assumes none of the dependencies have been installed
+# It will format geth to be a system service
+
+# Upgrade the system and install go, gcc, make, geth
+sudo apt-get install software-properties-common
+sudo add-apt-repository -y ppa:ethereum/ethereum
+sudo apt update
+sudo apt upgrade -y
+sudo apt install gcc make ethereum -y
+sudo snap install --classic go
+sudo mkdir -p ~/go/bin/
+
+# Export GO path and append to .bashrc file
+sed -i -e "\$aexport GOPATH=\$HOME/go\nexport PATH=\$GOPATH/bin:\$PATH" ~/.bashrc
+. ~/.bashrc
+
+# Install dep
+curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+# Install plasmad and plasmacli
+go get github.com/FourthState/plasma-mvp-sidechain
+cd ~/go/src/github.com/FourthState/plasma-mvp-sidechain/
+git fetch --all
+git checkout develop
+dep ensure
+cd server/plasmad/
+go install
+plasmad unsafe-reset-all
+cd ../../client/plasmacli/
+go install
+
+# Install npm, Truffle
+apt-get install nodejs
+apt-get install npm
+cd ~/go/src/github.com/FourthState/plasma-mvp-sidechain/contracts/
+npm install -g
+
+# setup geth as system service
+sudo useradd -m -d /opt/geth --system --shell /usr/sbin/nologin geth
+sudo -u geth mkdir -p /opt/geth/rinkeby
+cd /opt/geth/rinkeby/
+
+# geth.service
+echo "[Unit]
+Description=Geth
+After=network-online.target
+[Service]
+User=geth
+ExecStart=/usr/bin/geth --datadir=/opt/geth/rinkeby/chaindata/ --rinkeby --rpc --rpcapi db,eth,net,web3,personal
+Restart=always
+RestartSec=3
+LimitNOFILE=4096
+[Install]
+WantedBy=multi-user.target" > geth.service
+
+sudo mv geth.service /etc/systemd/system/
+sudo systemctl enable geth.service
+
+echo ""
+echo "Run 'sudo service geth start' to begin syncing to rinkeby network"
+echo "Set configuration parameters in ~./plasmacli/plasma.toml, ~/.plasmad/config/"
+echo ""

--- a/scripts/plasma_install.sh
+++ b/scripts/plasma_install.sh
@@ -13,6 +13,7 @@ sudo snap install --classic go
 sudo mkdir -p ~/go/bin/
 
 # Export GO path and append to .profile file
+echo "export PATH=\$PATH:/usr/local/go/bin" >> ~/.profile
 echo "export GOPATH=$HOME/go" >> ~/.profile
 echo "export PATH=\$PATH:\$GOPATH/bin" >> ~/.profile
 

--- a/scripts/plasma_install.sh
+++ b/scripts/plasma_install.sh
@@ -13,8 +13,9 @@ sudo snap install --classic go
 sudo mkdir -p ~/go/bin/
 
 # Export GO path and append to .bashrc file
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$PATH
 sed -i -e "\$aexport GOPATH=\$HOME/go\nexport PATH=\$GOPATH/bin:\$PATH" ~/.bashrc
-. ~/.bashrc
 
 # Install dep
 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/scripts/plasma_install.sh
+++ b/scripts/plasma_install.sh
@@ -12,10 +12,11 @@ sudo apt install gcc make ethereum -y
 sudo snap install --classic go
 sudo mkdir -p ~/go/bin/
 
-# Export GO path and append to .bashrc file
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:$PATH
-sed -i -e "\$aexport GOPATH=\$HOME/go\nexport PATH=\$GOPATH/bin:\$PATH" ~/.bashrc
+# Export GO path and append to .profile file
+echo "export GOPATH=$HOME/go" >> ~/.profile
+echo "export PATH=\$PATH:\$GOPATH/bin" >> ~/.profile
+
+source ~/.profile
 
 # Install dep
 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh

--- a/server/plasmad/config/config.go
+++ b/server/plasmad/config/config.go
@@ -51,7 +51,7 @@ func init() {
 }
 
 func DefaultPlasmaConfig() PlasmaConfig {
-	return PlasmaConfig{false, "", "", "", "", "0"}
+	return PlasmaConfig{false, "", "", "30s", "http://localhost:8545", "16"}
 }
 
 // parses the plasma.toml file and unmarshals it into a Config struct


### PR DESCRIPTION
Added installation script. Manually tested by installing on fresh digital ocean droplet.

Usage:
```
curl https://raw.githubusercontent.com/FourthState/plasma-mvp-sidechain/colin/scripts/scripts/plasma_install.sh > install.sh
chmod +x install.sh
./install.sh
```

Run `sudo service geth start` to bootup geth node syncing rinkeby network. 

Fixed plasmacli init bug, and add some defaults to plasmad plasma.toml