### PR TITLE
Colin/client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Plasma configuration file
 - Added IncludeDepositMsg with handling to allow explicit deposit inclusion into sidechain
 ### Changed
+- [\#129](https://github.com/FourthState/plasma-mvp-sidechain/pull/129) Updated sign command to iterate over an account to finalize transactions
+- [\#129](https://github.com/FourthState/plasma-mvp-sidechain/pull/129) Updated spend to auto generate transaction for users based on the utxos they own
 - [\#120](https://github.com/FourthState/plasma-mvp-sidechain/pull/118) Fixed Length TxBytes (811), compatible with rootchain v1.0.0
 - **plasmacli:** [\#108](https://github.com/FourthState/plasma-mvp-sidechain/pull/108) home flag renamed to directory, flags have suffix "F" for local flags, and "Flag" for persistent flags
 - **plasmacli:** [\#116](https://github.com/FourthState/plasma-mvp-sidechain/pull/116) client keystore/ renamed to store/

--- a/client/plasmacli/eth/finalize.go
+++ b/client/plasmacli/eth/finalize.go
@@ -28,7 +28,7 @@ Usage:
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		viper.BindPFlags(cmd.Flags())
 
-		key, err := store.GetKey(args[1])
+		key, err := store.GetKey(args[0])
 		if err != nil {
 			return fmt.Errorf("failed to retrieve account: { %s }", err)
 		}

--- a/client/plasmacli/eth/prove.go
+++ b/client/plasmacli/eth/prove.go
@@ -17,8 +17,8 @@ func ProveCmd() *cobra.Command {
 }
 
 var proveCmd = &cobra.Command{
-	Use:   "prove",
-	Short: "Prove transaction inclusion: prove <name> <position>",
+	Use:   "prove <account> <position>",
+	Short: "Prove transaction inclusion: prove <account> <position>",
 	Args:  cobra.ExactArgs(2),
 	Long:  "Returns proof for transaction inclusion. Use to exit transactions in the smart contract",
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -42,7 +42,7 @@ var proveCmd = &cobra.Command{
 		fmt.Printf("Roothash: 0x%x\n", result.Proof.RootHash)
 		fmt.Printf("Total: %d\n", result.Proof.Proof.Total)
 		fmt.Printf("LeafHash: 0x%x\n", result.Proof.Proof.LeafHash)
-		fmt.Printf("TxBytes: 0x%x\n", result.Tx)
+		fmt.Printf("TxBytes: 0x%x\n", []byte(result.Tx))
 
 		switch len(sigs) {
 		case 65:

--- a/client/plasmacli/eth/prove.go
+++ b/client/plasmacli/eth/prove.go
@@ -58,7 +58,11 @@ var proveCmd = &cobra.Command{
 		}
 
 		if len(proof) == 0 {
-			fmt.Printf("Proof: nil\n")
+			if result.Proof.Proof.Total == 1 {
+				fmt.Println("No proof required since this was the only transaction in the block")
+			} else {
+				fmt.Printf("Proof: nil\n")
+			}
 		} else {
 			fmt.Printf("Proof: 0x%x\n", proof)
 		}

--- a/client/plasmacli/eth/withdraw.go
+++ b/client/plasmacli/eth/withdraw.go
@@ -48,7 +48,7 @@ Usage:
 			return fmt.Errorf("failed to withdraw: { %s }", err)
 		}
 
-		fmt.Printf("Successfully sent withdraw transaction\nTransaction Hash: 0x%x", tx.Hash())
+		fmt.Printf("Successfully sent withdraw transaction\nTransaction Hash: 0x%x\n", tx.Hash())
 		return nil
 	},
 }

--- a/client/plasmacli/include.go
+++ b/client/plasmacli/include.go
@@ -16,9 +16,9 @@ import (
 
 func init() {
 	rootCmd.AddCommand(includeCmd)
-	includeCmd.Flags().Int64P(flagReplay, "r", 0, "Replay Nonce that can be incremented to allow for resubmissions of include deposit messages")
-	includeCmd.Flags().String(flagAddress, "", "address represented as hex string")
-	includeCmd.Flags().BoolP(flagSync, "s", false, "wait for transaction commitment synchronously")
+	includeCmd.Flags().Int64P(replayF, "r", 0, "Replay Nonce that can be incremented to allow for resubmissions of include deposit messages")
+	includeCmd.Flags().String(addressF, "", "address represented as hex string")
+	includeCmd.Flags().Bool(asyncF, false, "wait for transaction commitment synchronously")
 }
 
 var includeCmd = &cobra.Command{
@@ -42,7 +42,7 @@ var includeCmd = &cobra.Command{
 				return fmt.Errorf("Could not retrieve account: %s", args[1])
 			}
 		} else {
-			addrToken := viper.GetString(flagAddress)
+			addrToken := viper.GetString(addressF)
 			addrToken = strings.TrimSpace(addrToken)
 			if !ethcmn.IsHexAddress(addrToken) {
 				return fmt.Errorf("invalid address provided. please use hex format")
@@ -58,7 +58,7 @@ var includeCmd = &cobra.Command{
 			return fmt.Errorf("could not parse deposit nonce. Please resubmit with nonce in base 10")
 		}
 
-		replay := viper.GetInt(flagReplay)
+		replay := viper.GetInt(replayF)
 
 		msg := msgs.IncludeDepositMsg{
 			DepositNonce: nonce,
@@ -76,16 +76,16 @@ var includeCmd = &cobra.Command{
 		}
 
 		// broadcast to the node
-		if viper.GetBool(flagSync) {
+		if viper.GetBool(asyncF) {
+			if _, err := ctx.BroadcastTxAsync(txBytes); err != nil {
+				return err
+			}
+		} else {
 			res, err := ctx.BroadcastTxAndAwaitCommit(txBytes)
 			if err != nil {
 				return err
 			}
 			fmt.Printf("Committed at block %d. Hash %s\n", res.Height, res.TxHash)
-		} else {
-			if _, err := ctx.BroadcastTxAsync(txBytes); err != nil {
-				return err
-			}
 		}
 
 		return nil

--- a/client/plasmacli/include.go
+++ b/client/plasmacli/include.go
@@ -15,7 +15,6 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(includeCmd)
 	includeCmd.Flags().Int64P(replayF, "r", 0, "Replay Nonce that can be incremented to allow for resubmissions of include deposit messages")
 	includeCmd.Flags().String(addressF, "", "address represented as hex string")
 	includeCmd.Flags().Bool(asyncF, false, "wait for transaction commitment synchronously")

--- a/client/plasmacli/main.go
+++ b/client/plasmacli/main.go
@@ -19,14 +19,14 @@ var homeDir string = os.ExpandEnv("$HOME/.plasmacli/")
 
 // Flags
 const (
-	accountF         = "accounts"
-	ownerF           = "owner"
-	positionF        = "position"
-	flagConfirmSigs0 = "Input0ConfirmSigs"
-	flagConfirmSigs1 = "Input1ConfirmSigs"
-	flagInputs       = "inputValues"
-	flagSync         = "sync"
-	flagFee          = "fee"
+	accountF      = "accounts"
+	ownerF        = "owner"
+	positionF     = "position"
+	confirmSigs0F = "Input0ConfirmSigs"
+	confirmSigs1F = "Input1ConfirmSigs"
+	flagInputs    = "inputValues"
+	asyncF        = "async"
+	feeF          = "fee"
 )
 
 var rootCmd = &cobra.Command{

--- a/client/plasmacli/main.go
+++ b/client/plasmacli/main.go
@@ -19,9 +19,9 @@ var homeDir string = os.ExpandEnv("$HOME/.plasmacli/")
 
 // Flags
 const (
-	flagAccount      = "accounts"
-	flagOwner        = "owner"
-	flagPositions    = "position"
+	accountF         = "accounts"
+	ownerF           = "owner"
+	positionF        = "position"
 	flagConfirmSigs0 = "Input0ConfirmSigs"
 	flagConfirmSigs1 = "Input1ConfirmSigs"
 	flagInputs       = "inputValues"
@@ -35,19 +35,8 @@ var rootCmd = &cobra.Command{
 }
 
 func main() {
-	Execute()
-}
+	cobra.EnableCommandSorting = false
 
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-}
-
-func init() {
-	// initConfig to be ran when Execute is called
-	cobra.OnInitialize(initConfig)
 	rootCmd.Flags().String(client.FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
 	rootCmd.PersistentFlags().StringP(store.DirFlag, "d", homeDir, "directory for plasmacli")
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
@@ -68,11 +57,31 @@ func init() {
 	}
 
 	rootCmd.AddCommand(
-		keys.KeysCmd(),
-		query.QueryCmd(),
 		eth.EthCmd(),
+		query.QueryCmd(),
 		eth.ProveCmd(),
+		client.LineBreak,
+		signCmd,
+		spendCmd,
+		client.LineBreak,
+		keys.KeysCmd(),
+		client.LineBreak,
+		versionCmd,
 	)
+
+	Execute()
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func init() {
+	// initConfig to be ran when Execute is called
+	cobra.OnInitialize(initConfig)
 }
 
 // initConfig reads in config file and ENV variables if set

--- a/client/plasmacli/main.go
+++ b/client/plasmacli/main.go
@@ -36,6 +36,11 @@ var rootCmd = &cobra.Command{
 	Short: "Plasma Client",
 }
 
+func init() {
+	// initConfig to be ran when Execute is called
+	cobra.OnInitialize(initConfig)
+}
+
 func main() {
 	cobra.EnableCommandSorting = false
 
@@ -63,6 +68,7 @@ func main() {
 		eth.EthCmd(),
 		query.QueryCmd(),
 		eth.ProveCmd(),
+		includeCmd,
 		client.LineBreak,
 		signCmd,
 		spendCmd,
@@ -80,11 +86,6 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-}
-
-func init() {
-	// initConfig to be ran when Execute is called
-	cobra.OnInitialize(initConfig)
 }
 
 // initConfig reads in config file and ENV variables if set

--- a/client/plasmacli/query/account.go
+++ b/client/plasmacli/query/account.go
@@ -15,7 +15,6 @@ func init() {
 	queryCmd.AddCommand(balanceCmd)
 }
 
-// TODO: Change to querying account, add flag for getting all info
 var balanceCmd = &cobra.Command{
 	Use:   "balance <name>",
 	Short: "Query account balance",

--- a/client/plasmacli/query/block.go
+++ b/client/plasmacli/query/block.go
@@ -1,7 +1,6 @@
 package query
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/cosmos/cosmos-sdk/client/context"
@@ -42,13 +41,7 @@ var blockCmd = &cobra.Command{
 			return err
 		}
 
-		resp, err := json.Marshal(block)
-		if err != nil {
-			fmt.Println("error marshaling")
-			return err
-		}
-
-		fmt.Printf("Block Data\n%s\n", resp)
+		fmt.Printf("Header: %x\nTxs: %d\nFee: %d\n", block.Header, block.TxnCount, block.FeeAmount)
 		return nil
 	},
 }

--- a/client/plasmacli/query/info.go
+++ b/client/plasmacli/query/info.go
@@ -11,8 +11,10 @@ import (
 	"strings"
 )
 
-// TODO: Change this from being a command to a flag for the account command
-// If --all then print all info for account
+func init() {
+	queryCmd.AddCommand(infoCmd)
+}
+
 var infoCmd = &cobra.Command{
 	Use:   "info <address>",
 	Args:  cobra.ExactArgs(1),

--- a/client/plasmacli/sign.go
+++ b/client/plasmacli/sign.go
@@ -6,6 +6,7 @@ import (
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/FourthState/plasma-mvp-sidechain/store"
 	"github.com/FourthState/plasma-mvp-sidechain/utils"
+	cosmoscli "github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/codec"
 	ethcmn "github.com/ethereum/go-ethereum/common"
@@ -15,60 +16,125 @@ import (
 	"strings"
 )
 
+const (
+	signPrompt = "Would you like to finalize this transaction? [Y/n]"
+)
+
 func init() {
-	rootCmd.AddCommand(signCmd)
-	signCmd.Flags().StringP(flagAccount, "a", "", "Account to sign the confirmation signature with (required)")
-	signCmd.Flags().String(flagOwner, "", "Owner of the output (required)")
+	signCmd.Flags().String(ownerF, "", "Owner of the output (required with position flag)")
+	signCmd.Flags().String(positionF, "", "Position of transaction to finalize (required with owner flag)")
 }
 
 var signCmd = &cobra.Command{
-	Use:   "sign <position>",
-	Short: "Sign confirmation signatures for position provided (blockNum.txIndex.oIndex.depositNonce), if it exists.",
-	Args:  cobra.ExactArgs(1),
+	Use:   "sign <account>",
+	Short: "Sign confirmation signatures for pending transactions",
+	Long: `Iterate over all unfinalized transaction corresponding to the provided account. 
+Prompt the user for confirmation to finailze the pending transactions. Owner and Position flags can be used to finalize a specific transaction.
+
+Usage:
+	plasmacli sign <account>
+	plasmacli sign <account> --owner <address> --position "(blknum.txindex.oindex.depositnonce)"`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		viper.BindPFlags(cmd.Flags())
 		ctx := context.NewCLIContext().WithCodec(codec.New()).WithTrustNode(true)
 
-		position, err := plasma.FromPositionString(strings.TrimSpace(args[0]))
-		if err != nil {
-			fmt.Println("Error parsing positions")
+		name := args[0]
+
+		ownerS := viper.GetString(ownerF)
+		positionS := viper.GetString(positionF)
+		if ownerS != "" || positionS != "" {
+			err := signSingleConfirmSig(ctx, ownerS, positionS, name)
 			return err
 		}
 
-		name := viper.GetString(flagAccount)
-
-		ownerStr := utils.RemoveHexPrefix(strings.TrimSpace(viper.GetString(flagOwner)))
-		if ownerStr == "" || !ethcmn.IsHexAddress(ownerStr) {
-			return fmt.Errorf("must provide the address that owns position %s using the --owner flag in hex format", position)
+		addr, err := clistore.GetAccount(name)
+		if err != nil {
+			return err
 		}
-		ownerAddr := ethcmn.HexToAddress(ownerStr)
 
-		// retrieve the new output
+		res, err := ctx.QuerySubspace(addr.Bytes(), "utxo")
+		if err != nil {
+			return err
+		}
+
 		utxo := store.UTXO{}
-		key := append(ownerAddr.Bytes(), position.Bytes()...)
-		res, err := ctx.QueryStore(key, "utxo")
-		if err != nil {
-			return err
-		}
-		if err := rlp.DecodeBytes(res, &utxo); err != nil {
-			return err
-		}
+		for _, pair := range res {
+			if err := rlp.DecodeBytes(pair.Value, &utxo); err != nil {
+				return err
+			}
 
-		// create the signature
-		hash := utils.ToEthSignedMessageHash(utxo.ConfirmationHash)
-		sig, err := clistore.SignHashWithPassphrase(name, hash)
-		if err != nil {
-			return err
+			if utxo.Spent {
+				// check if confirmation signature already stored
+				if _, err := clistore.GetSig(utxo.Position); err != nil {
+					// get confirmation to generate signature
+					fmt.Printf("\nUTXO\nPosition: %s\nOwner: 0x%x\nValue: %d\n", utxo.Position, utxo.Output.Owner, utxo.Output.Amount)
+					buf := cosmoscli.BufferStdin()
+					auth, err := cosmoscli.GetString(signPrompt, buf)
+					if err != nil {
+						continue
+					}
+					if auth != "Y" {
+						continue
+					}
+
+					err = sign(utxo, name)
+					if err != nil {
+						fmt.Println(err)
+					}
+				}
+			}
+
 		}
-
-		if err := clistore.SaveSig(position, sig); err != nil {
-			return err
-		}
-
-		// print the results
-		fmt.Printf("Confirmation Signature for output with position: %s\n", utxo.Position)
-		fmt.Printf("0x%x\n", sig)
-
 		return nil
 	},
+}
+
+// generate confirmation signature for given utxo
+func sign(utxo store.UTXO, name string) error {
+	hash := utils.ToEthSignedMessageHash(utxo.ConfirmationHash)
+	sig, err := clistore.SignHashWithPassphrase(name, hash)
+	if err != nil {
+		return fmt.Errorf("failed to generate confirmation signature: { %s }", err)
+	}
+
+	if err := clistore.SaveSig(utxo.Position, sig); err != nil {
+		return err
+	}
+
+	// print the results
+	fmt.Printf("Confirmation Signature for output with position: %s\n", utxo.Position)
+	fmt.Printf("0x%x\n", sig)
+	return nil
+}
+
+// generate confirmation signature for specified owner and position
+func signSingleConfirmSig(ctx context.CLIContext, ownerS, positionS, name string) error {
+	position, err := plasma.FromPositionString(strings.TrimSpace(viper.GetString(positionF)))
+	if err != nil {
+		return err
+	}
+
+	ownerStr := utils.RemoveHexPrefix(strings.TrimSpace(viper.GetString(ownerF)))
+	if ownerStr == "" || !ethcmn.IsHexAddress(ownerStr) {
+		return fmt.Errorf("must provide the address that owns position %s using the --owner flag in hex format", position)
+	}
+	ownerAddr := ethcmn.HexToAddress(ownerStr)
+
+	// retrieve the new output
+	utxo := store.UTXO{}
+	key := append(ownerAddr.Bytes(), position.Bytes()...)
+	res, err := ctx.QueryStore(key, "utxo")
+	if err != nil {
+		return err
+	}
+
+	if err := rlp.DecodeBytes(res, &utxo); err != nil {
+		return err
+	}
+
+	if err := sign(utxo, name); err != nil {
+		return err
+	}
+	return nil
 }

--- a/client/plasmacli/sign.go
+++ b/client/plasmacli/sign.go
@@ -64,7 +64,7 @@ Usage:
 				return err
 			}
 
-			if utxo.Spent {
+			if !utxo.Spent {
 				err = verifyAndSign(utxo, addr, name)
 				if err != nil {
 					fmt.Println(err)
@@ -112,11 +112,12 @@ func signSingleConfirmSig(ctx context.CLIContext, addr ethcmn.Address, ownerS, p
 // generate confirmation signature for given utxo
 func verifyAndSign(utxo store.UTXO, addr ethcmn.Address, name string) error {
 	sig, _ := clistore.GetSig(utxo.Position)
-	if len(sig) == 130 {
+	inputAddrs := utxo.InputAddresses()
+
+	if len(sig) == 130 || (len(sig) == 65 && len(inputAddrs) == 1) {
 		return nil
 	}
 
-	inputAddrs := utxo.InputAddresses()
 	for i, input := range inputAddrs {
 		if input != addr {
 			continue

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -352,7 +352,7 @@ func retrieveInputs(accs []string, total *big.Int) (inputs []plasma.Position, ch
 		if err != nil {
 			return nil, nil, fmt.Errorf("Must connect full eth node or specify inputs using flags. Error encountered: %s", err)
 		}
-		if exitted {
+		if exitted || utxo0.Spent {
 			continue
 		}
 		// check if first utxo satisfies transfer amount
@@ -366,16 +366,16 @@ func retrieveInputs(accs []string, total *big.Int) (inputs []plasma.Position, ch
 				continue
 			}
 
-			exitted, err := eth.HasTxExitted(utxo0.Position)
+			if err := rlp.DecodeBytes(inner.Value, &utxo1); err != nil {
+				return nil, nil, err
+			}
+
+			exitted, err := eth.HasTxExitted(utxo1.Position)
 			if err != nil {
 				return nil, nil, fmt.Errorf("Must connect full eth node or specify inputs using flags. Error encountered: %s", err)
 			}
-			if exitted {
+			if exitted || utxo1.Spent {
 				continue
-			}
-
-			if err := rlp.DecodeBytes(inner.Value, &utxo1); err != nil {
-				return nil, nil, err
 			}
 
 			// check if only utxo1 satisfies transfer amount

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -81,6 +81,9 @@ Usage:
 			if err != nil {
 				return err
 			}
+			if len(inputs) == 0 {
+				return fmt.Errorf("failed to generate a valid transaction. Please provide the inputs")
+			}
 		}
 
 		// get confirmation signatures from local storage

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 var spendCmd = &cobra.Command{
-	Use:   "spend <to> <amount> <account>",
+	Use:   "spend <from> <amount> <to>",
 	Short: "Send a transaction spending utxos",
 	Long: `Send a transaction spending from the specified account. If sending to multiple addresses, the account specified must contain exact utxo values.
 If a single spending account is specified, leftover value from spending the utxo will be sent back to the account. 
@@ -40,9 +40,9 @@ In the case that the spending account does not have a large enough single utxo, 
 <to> in the following usage is the address being sent the utxo amounts.
 
 Usage:
-	plasmacli <to> <amount> <account>
-	plasmacli <to,to> <amount,amount> <account,account> --fee <fee>
-	plasmacli <to> <amount> <account> --confirmSigs0 <signature> --confirmSig1 <signature>`,
+	plasmacli <from> <amount> <to>
+	plasmacli <from,from> <amount,amount> <to,to> --fee <fee>
+	plasmacli <from> <amount> <to> --confirmSigs0 <signature> --confirmSig1 <signature>`,
 	Args: cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		viper.BindPFlags(cmd.Flags())
@@ -50,7 +50,7 @@ Usage:
 
 		// parse accounts
 		var accs []string
-		names := args[2]
+		names := args[0]
 
 		accTokens := strings.Split(strings.TrimSpace(names), ",")
 		if len(accTokens) == 0 || len(accTokens) > 2 {
@@ -60,7 +60,7 @@ Usage:
 			accs = append(accs, strings.TrimSpace(token))
 		}
 
-		toAddrs, err := parseToAddresses(args[0])
+		toAddrs, err := parseToAddresses(args[2])
 		if err != nil {
 			return err
 		}

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/hex"
 	"fmt"
+	"github.com/FourthState/plasma-mvp-sidechain/client/plasmacli/eth"
 	clistore "github.com/FourthState/plasma-mvp-sidechain/client/store"
 	"github.com/FourthState/plasma-mvp-sidechain/msgs"
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
@@ -346,6 +347,14 @@ func retrieveInputs(accs []string, total *big.Int) (inputs []plasma.Position, ch
 		if err := rlp.DecodeBytes(outer.Value, &utxo0); err != nil {
 			return nil, nil, err
 		}
+
+		exitted, err := eth.HasTxExitted(utxo0.Position)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Must connect full eth node or specify inputs using flags. Error encountered: %s", err)
+		}
+		if exitted {
+			continue
+		}
 		// check if first utxo satisfies transfer amount
 		if utxo0.Output.Amount.Cmp(total) == 0 {
 			inputs = append(inputs, utxo0.Position)
@@ -354,6 +363,14 @@ func retrieveInputs(accs []string, total *big.Int) (inputs []plasma.Position, ch
 		for k, inner := range res {
 			// do not pair an input with itself
 			if i == k {
+				continue
+			}
+
+			exitted, err := eth.HasTxExitted(utxo0.Position)
+			if err != nil {
+				return nil, nil, fmt.Errorf("Must connect full eth node or specify inputs using flags. Error encountered: %s", err)
+			}
+			if exitted {
 				continue
 			}
 

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -81,6 +81,7 @@ Usage:
 			if err != nil {
 				return err
 			}
+
 			if len(inputs) == 0 {
 				return fmt.Errorf("failed to generate a valid transaction. Please provide the inputs")
 			}

--- a/client/plasmacli/spend.go
+++ b/client/plasmacli/spend.go
@@ -18,49 +18,46 @@ import (
 )
 
 func init() {
-	rootCmd.AddCommand(spendCmd)
-	spendCmd.Flags().String(flagPositions, "", "UTXO Positions to be spent, format: (blknum0.txindex0.oindex0.depositnonce0)::(blknum1.txindex1.oindex1.depositnonce1)")
+	spendCmd.Flags().String(positionF, "", "UTXO Positions to be spent, format: (blknum0.txindex0.oindex0.depositnonce0)::(blknum1.txindex1.oindex1.depositnonce1)")
+	spendCmd.Flags().StringP(confirmSigs0F, "0", "", "Input Confirmation Signatures for first input to be spent (separated by commas)")
+	spendCmd.Flags().StringP(confirmSigs1F, "1", "", "Input Confirmation Signatures for second input to be spent (separated by commas)")
 
-	spendCmd.Flags().String(flagConfirmSigs0, "", "Input Confirmation Signatures for first input to be spent (separated by commas)")
-	spendCmd.Flags().String(flagConfirmSigs1, "", "Input Confirmation Signatures for second input to be spent (separated by commas)")
-
-	spendCmd.Flags().String(flagFee, "0", "Fee to be spent")
-	spendCmd.Flags().StringP(flagAccount, "a", "", "Accounts to sign with if using different accounts")
-	spendCmd.Flags().StringP(flagInputs, "i", "", "Input amounts to be spent if using multiple accounts")
+	spendCmd.Flags().String(feeF, "0", "Fee to be spent")
 
 	spendCmd.Flags().String(client.FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
-	spendCmd.Flags().BoolP(flagSync, "s", false, "wait for transaction commitment synchronously")
-	viper.BindPFlags(spendCmd.Flags())
+	spendCmd.Flags().Bool(asyncF, false, "broadcast transactions asynchronously")
 }
 
 var spendCmd = &cobra.Command{
 	Use:   "spend <to> <amount> <account>",
 	Short: "Send a transaction spending utxos",
-	Long: `Example usage:
-plasmacli <to> <amount> <account>
-plasmacli <to,to> <amount,amount> <account> --fee <fee>
-plasmacli <to> <amount>  -a <account>,<account> -in <amount>,<amount>`,
-	Args: cobra.MinimumNArgs(2),
+	Long: `Send a transaction spending from the specified account. If sending to multiple addresses, the account specified must contain exact utxo values.
+If a single spending account is specified, leftover value from spending the utxo will be sent back to the account. 
+In the case that the spending account does not have a large enough single utxo, two input utxos will be used. User can override retireved data with position and confirm signature flags.
+<to> in the following usage is the address being sent the utxo amounts.
+
+Usage:
+	plasmacli <to> <amount> <account>
+	plasmacli <to,to> <amount,amount> <account,account> --fee <fee>
+	plasmacli <to> <amount> <account> --confirmSigs0 <signature> --confirmSig1 <signature>`,
+	Args: cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		viper.BindPFlags(cmd.Flags())
 		ctx := context.NewCLIContext()
 
 		// parse accounts
 		var accs []string
-		names := viper.GetString(flagAccount)
-		if names != "" {
-			accTokens := strings.Split(strings.TrimSpace(names), ",")
-			if len(accTokens) == 0 || len(accTokens) > 2 {
-				return fmt.Errorf("1 or 2 accounts must be specified")
-			}
+		names := args[2]
 
-			for _, token := range accTokens {
-				accs = append(accs, strings.TrimSpace(token))
-			}
-		} else {
-			accs = append(accs, args[2])
+		accTokens := strings.Split(strings.TrimSpace(names), ",")
+		if len(accTokens) == 0 || len(accTokens) > 2 {
+			return fmt.Errorf("1 or 2 accounts must be specified")
+		}
+		for _, token := range accTokens {
+			accs = append(accs, strings.TrimSpace(token))
 		}
 
-		// validate addresses
+		// parse to addresses
 		var toAddrs []ethcmn.Address
 		toAddrTokens := strings.Split(strings.TrimSpace(args[0]), ",")
 		if len(toAddrTokens) == 0 || len(toAddrTokens) > 2 {
@@ -79,75 +76,50 @@ plasmacli <to> <amount>  -a <account>,<account> -in <amount>,<amount>`,
 			toAddrs = append(toAddrs, addr)
 		}
 
-		// validate confirm signatures
-		var confirmSignatures [2][][65]byte
-		for i := 0; i < 2; i++ {
-			var flag string
-			if i == 0 {
-				flag = flagConfirmSigs0
-			} else {
-				flag = flagConfirmSigs1
-
-			}
-			confirmSigTokens := strings.Split(strings.TrimSpace(viper.GetString(flag)), ",")
-			// empty confirmsig
-			if len(confirmSigTokens) == 1 && confirmSigTokens[0] == "" {
-				continue
-			} else if len(confirmSigTokens) > 2 {
-				return fmt.Errorf("only pass in 0, 1 or 2, confirm signatures")
-			}
-
-			var confirmSignature [][65]byte
-			for _, token := range confirmSigTokens {
-				token := strings.TrimSpace(token)
-				sig, err := hex.DecodeString(token)
-				if err != nil {
-					return err
-				}
-				if len(sig) != 65 {
-					return fmt.Errorf("signatures must be of length 65 bytes")
-				}
-
-				var signature [65]byte
-				copy(signature[:], sig)
-				confirmSignature = append(confirmSignature, signature)
-			}
-
-			confirmSignatures[i] = confirmSignature
-		}
-
-		// validate inputs
-		var inputs []plasma.Position
-		positions := strings.Split(strings.TrimSpace(viper.GetString(flagPositions)), "::")
-		if len(positions) > 2 || len(positions) == 0 {
-			return fmt.Errorf("only pass in 1 or 2 positions")
-		}
-		for _, token := range positions {
-			token = strings.TrimSpace(token)
-			position, err := plasma.FromPositionString(token)
-			if err != nil {
-				return err
-			}
-
-			inputs = append(inputs, position)
-		}
-
-		// validate amounts and fee
-		var amounts []*big.Int // [amount0, amount1, fee]
+		// parse amounts
+		var amounts []*big.Int // [amount0, amount1]
+		var total int64
 		amountTokens := strings.Split(strings.TrimSpace(args[1]), ",")
-		if len(amountTokens) != 2 && len(amountTokens) != 3 {
-			return fmt.Errorf("number of amounts must equal the number of outputs in addition to the fee")
+		if len(amountTokens) != 1 && len(amountTokens) != 2 {
+			return fmt.Errorf("1 or 2 output amounts must be specified")
 		}
-		if len(amountTokens)-1 != len(toAddrs) {
+		if len(amountTokens) != len(toAddrs) {
 			return fmt.Errorf("provided amounts to not match the number of outputs")
 		}
 		for _, token := range amountTokens {
 			token = strings.TrimSpace(token)
 			num, ok := new(big.Int).SetString(token, 10)
 			if !ok {
-				return fmt.Errorf("error parsing number: %s", token)
+				return fmt.Errorf("failed to parsing amount: %s", token)
 			}
+			total += num.Int64()
 			amounts = append(amounts, num)
+		}
+
+		// parse fee
+		fee, ok := new(big.Int).SetString(strings.TrimSpace(viper.GetString(feeF)), 10)
+		if !ok {
+			return fmt.Errof("failed to parse fee: %s", fee)
+		}
+
+		total += fee.Int64()
+		inputs, change, err := getInputs(total)
+		if err != nil {
+			return err
+		}
+
+		// get confirmation signatures from local storage
+		var confirmSignatures [2][][65]byte
+		for i, input := range inputs {
+			sig, err := store.GetSig(input)
+			if sig != nil {
+				confirmSignatures[i] = sig
+			}
+		}
+
+		confirmSignatures, inputs, overriden, err := parseSpend(confirmSignatures, inputs)
+		if err != nil {
+			return err
 		}
 
 		// create the transaction without signatures
@@ -158,14 +130,24 @@ plasmacli <to> <amount>  -a <account>,<account> -in <amount>,<amount>`,
 		} else {
 			tx.Input1 = plasma.NewInput(plasma.NewPosition(nil, 0, 0, nil), [65]byte{}, nil)
 		}
+
 		tx.Output0 = plasma.NewOutput(toAddrs[0], amounts[0])
 		if len(toAddrs) > 1 {
-			tx.Output1 = plasma.NewOutput(toAddrs[1], amounts[1])
-			tx.Fee = amounts[2]
+			if change == 0 || overriden {
+				tx.Output1 = plasma.NewOutput(toAddrs[1], amounts[1])
+			} else {
+				return fmt.Errorf("cannot spend to two addresses since exact utxo inputs could not be found")
+			}
+		} else if change > 0 && !overriden {
+			addr, err := store.GetAccount(accs[0])
+			if err != nil {
+				return err
+			}
+			tx.Output1 = plasma.NewOutput(addr, big.NewInt(change))
 		} else {
 			tx.Output1 = plasma.NewOutput(ethcmn.Address{}, nil)
-			tx.Fee = amounts[1]
 		}
+		tx.Fee = fee
 
 		// create and fill in the signatures
 		signer := accs[0]
@@ -203,18 +185,144 @@ plasmacli <to> <amount>  -a <account>,<account> -in <amount>,<amount>`,
 		}
 
 		// broadcast to the node
-		if viper.GetBool(flagSync) {
+		if viper.GetBool(asyncF) {
+			if _, err := ctx.BroadcastTxAsync(txBytes); err != nil {
+				return err
+			}
+		} else {
 			res, err := ctx.BroadcastTxAndAwaitCommit(txBytes)
 			if err != nil {
 				return err
 			}
 			fmt.Printf("Committed at block %d. Hash 0x%x\n", res.Height, res.TxHash)
-		} else {
-			if _, err := ctx.BroadcastTxAsync(txBytes); err != nil {
-				return err
-			}
 		}
 
 		return nil
 	},
+}
+
+// attempt to retrieve to generate a valid spend transaction
+// returns sum(inputs) - total
+func getInputs(accs []string, total *big.Int) (inputs []plasma.Position, change *big.Int, err error) {
+	ctx := context.NewCLIContext().WithCodec(codec.New()).WithTrustNode(true)
+	change = 0 - total
+	// must specifiy inputs if using two accounts
+	if len(accs) > 1 {
+		return inputs, change, nil
+	}
+
+	addr, err := store.GetAccount(accs[0])
+	if err != nil {
+		return inputs, change, err
+	}
+
+	res, err := ctx.QuerySubspace(addr.Bytes(), "utxo")
+	if err != nil {
+		return inputs, change, err
+	}
+
+	var optimalChange = total
+	var position0, position1 plasma.Position
+	// iterate through utxo's looking for optimal input pairing
+	// return input pairing if input + input == total
+	utxo0 := store.UTXO{}
+	utxo1 := store.UTXO{}
+	for i, outer := range res {
+		if err := rlp.DecodeBytes(outer.Value, &utxo0); err != nil {
+			return err
+		}
+
+		for k, inner := range res {
+			// do not pair an input with itself
+			if i == k {
+				continue
+			}
+
+			if err := rlp.DecodeBytes(inner.Value, &utxo1); err != nil {
+				return err
+			}
+
+			// check for exact match
+			sum := new(big.Int).Add(utxo0.Output.Amount, utxo1.Output.Amount)
+			if sum.Cmp(total) == 0 {
+				inputs = append(utxo0.Position, utxo1.Position)
+				return inputs, big.NewInt(0), nil
+			}
+
+			diff := new(big.Int).Sub(sum, total)
+			if diff.Int64() > 0 && diff.Cmp(optimalChange) == -1 {
+				optimalChange = diff
+				position0 = utxo0.Position
+				position1 = utxo1.Position
+			}
+
+		}
+	}
+
+	inputs = append(position0, position1)
+	return inputs, optimalChange, nil
+}
+
+// Parse flags related to spending
+// Flags override locally retrieved information
+// bool returned specifies if inputs found were overriden
+func parseSpend(confirmSignatures [2][][65]byte, inputs []plasma.Position) ([2][][65]byte, []plasma.Position, bool.error) {
+	// validate confirm signatures
+	for i := 0; i < 2; i++ {
+		var flag string
+		if i == 0 {
+			flag = confirmSigs0F
+		} else {
+			flag = confirmSigs1F
+
+		}
+		confirmSigTokens := strings.Split(strings.TrimSpace(viper.GetString(flag)), ",")
+		// empty confirmsig
+		if len(confirmSigTokens) == 1 && confirmSigTokens[0] == "" {
+			continue
+		} else if len(confirmSigTokens) > 2 {
+			return fmt.Errorf("only pass in 0, 1 or 2, confirm signatures")
+		}
+
+		var confirmSignature [][65]byte
+		for _, token := range confirmSigTokens {
+			token := strings.TrimSpace(token)
+			sig, err := hex.DecodeString(token)
+			if err != nil {
+				return err
+			}
+			if len(sig) != 65 {
+				return fmt.Errorf("signatures must be of length 65 bytes")
+			}
+
+			var signature [65]byte
+			copy(signature[:], sig)
+			confirmSignature = append(confirmSignature, signature)
+		}
+
+		confirmSignatures[i] = confirmSignature
+	}
+
+	// parse inputs
+	positions := strings.Split(strings.TrimSpace(viper.GetString(positionF)), "::")
+	if len(positions) == 0 {
+		if len(inputs) != 0 {
+			return confirmSignatures, inputs, false, nil
+		} else {
+			return nil, nil, fmt.Errorf("must specifiy inputs to be used if two accounts are used")
+		}
+	}
+	if len(positions) > 2 {
+		return fmt.Errorf("only pass in 1 or 2 positions")
+	}
+	for _, token := range positions {
+		token = strings.TrimSpace(token)
+		position, err := plasma.FromPositionString(token)
+		if err != nil {
+			return err
+		}
+		inputs = append(inputs, position)
+	}
+
+	return confirmSignatures, inputs, true, nil
 }

--- a/client/plasmacli/version.go
+++ b/client/plasmacli/version.go
@@ -5,10 +5,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	rootCmd.AddCommand(versionCmd)
-}
-
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of the plasma client",

--- a/client/store/keystore.go
+++ b/client/store/keystore.go
@@ -97,7 +97,7 @@ func GetAccount(name string) (ethcmn.Address, error) {
 
 	addr, err := db.Get([]byte(name), nil)
 	if err != nil {
-		return ethcmn.Address{}, err
+		return ethcmn.Address{}, fmt.Errorf("failed to find account: %s", name)
 	}
 
 	return ethcmn.BytesToAddress(addr), nil

--- a/client/store/keystore.go
+++ b/client/store/keystore.go
@@ -161,7 +161,7 @@ func UpdateAccount(name string, updatedName string) (msg string, err error) {
 		// Update passphrase
 		buf := cosmoscli.BufferStdin()
 		password, err := cosmoscli.GetPassword(PassphrasePrompt, buf)
-		updatedPassword, err := cosmoscli.GetPassword(NewPassphrasePrompt, buf)
+		updatedPassword, err := cosmoscli.GetCheckPassword(NewPassphrasePrompt, NewPassphrasePromptRepeat, buf)
 		if err != nil {
 			return msg, err
 		}

--- a/client/store/sigs.go
+++ b/client/store/sigs.go
@@ -57,7 +57,7 @@ func GetSig(position plasma.Position) ([]byte, error) {
 
 	k := getSigKey(position)
 	if sig, err := db.Get(k, nil); err != nil {
-		return nil, fmt.Errorf("failed to get signature: { %s }", err)
+		return []byte{}, fmt.Errorf("failed to get signature: { %s }", err)
 	} else {
 		return sig, nil
 	}

--- a/client/store/sigs.go
+++ b/client/store/sigs.go
@@ -10,9 +10,27 @@ const (
 	signatureDir = "data/signatures.ldb"
 )
 
-// Saves confirmation signature
-// Overrides any value previously set at the given position
-func SaveSig(position plasma.Position, sig []byte) error {
+// Saves confirmation signatures
+// If prepend is set to true, sig will be prepended to the currently stored signatures
+// Otherwise it will be appended
+// This ordering should be determined by input order in the transaction
+// If the length of the currently stored signatures is 130 an error is returned
+func SaveSig(position plasma.Position, sig []byte, prepend bool) error {
+	if len(sig) != 65 {
+		return fmt.Errorf("signature must have a length of 65 bytes")
+	}
+
+	signatures, err := GetSig(position)
+	if len(signatures) == 130 {
+		return fmt.Errorf("two signatures already exist for the given position")
+	}
+
+	if prepend {
+		signatures = append(sig, signatures...)
+	} else {
+		signatures = append(signatures, sig...)
+	}
+
 	dir := getDir(signatureDir)
 	db, err := leveldb.OpenFile(dir, nil)
 	if err != nil {
@@ -21,7 +39,7 @@ func SaveSig(position plasma.Position, sig []byte) error {
 	defer db.Close()
 
 	k := getSigKey(position)
-	if err := db.Put(k, sig, nil); err != nil {
+	if err := db.Put(k, signatures, nil); err != nil {
 		return fmt.Errorf("failed to save confirmation signature: { %s }", err)
 	}
 

--- a/client/store/sigs_test.go
+++ b/client/store/sigs_test.go
@@ -43,7 +43,7 @@ func TestSavSig(t *testing.T) {
 		_, err = GetSig(pos)
 		require.Errorf(t, err, "case %d: did not error when getting non existent signature for position %s", i, pos)
 
-		err = SaveSig(pos, expected)
+		err = SaveSig(pos, expected, true)
 		require.NoError(t, err, "case %d: failed to save signature for position %s", i, pos)
 
 		actual, err := GetSig(pos)

--- a/client/store/sigs_test.go
+++ b/client/store/sigs_test.go
@@ -61,3 +61,61 @@ func TestSavSig(t *testing.T) {
 		}
 	}
 }
+
+// pass in a signature without length 65 bytes
+func TestBadSigs(t *testing.T) {
+	// setup testing env
+	os.Mkdir("testing", os.ModePerm)
+	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+
+	// cleanup
+	defer func() {
+		viper.Reset()
+		os.RemoveAll("testing")
+
+	}()
+
+	key, _ := crypto.GenerateKey()
+	txHash := crypto.Keccak256([]byte("transaction hash"))
+
+	sig, _ := crypto.Sign(txHash, key)
+	pos := plasma.NewPosition(big.NewInt(10), uint16(5), uint8(0), big.NewInt(0))
+
+	err := SaveSig(pos, sig[:60], true)
+	require.Error(t, err, "did not reject a signature with a length not equal to 65")
+}
+
+// Save two confirmation signatures
+func TestMultiConfirmSig(t *testing.T) {
+	// setup testing env
+	os.Mkdir("testing", os.ModePerm)
+	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+
+	// cleanup
+	defer func() {
+		viper.Reset()
+		os.RemoveAll("testing")
+
+	}()
+
+	key, _ := crypto.GenerateKey()
+	txHash0 := crypto.Keccak256([]byte("hash one"))
+	txHash1 := crypto.Keccak256([]byte("the second hash"))
+
+	sig0, _ := crypto.Sign(txHash0, key)
+	sig1, _ := crypto.Sign(txHash1, key)
+
+	pos := plasma.NewPosition(big.NewInt(1000), uint16(256), uint8(0), big.NewInt(0))
+
+	// save sig1 first
+	err := SaveSig(pos, sig1, false)
+	require.NoError(t, err, "failed to save first confirm signature")
+
+	// prepend sig0
+	err = SaveSig(pos, sig0, true)
+	require.NoError(t, err, "failed to save second confirm signature")
+
+	sigs, err := GetSig(pos)
+	require.NoError(t, err, "failed to retrieve confirm signatures")
+	require.Equal(t, append(sig0, sig1...), sigs, "retrieved signatures do not match expected signatures")
+}

--- a/handlers/anteHandler.go
+++ b/handlers/anteHandler.go
@@ -84,9 +84,9 @@ func spendMsgAnteHandler(ctx sdk.Context, spendMsg msgs.SpendMsg, utxoStore stor
 	// input0 + input1 (totalInputAmt) == output0 + output1 + Fee (totalOutputAmt)
 	totalOutputAmt = spendMsg.Output0.Amount
 	if spendMsg.HasSecondOutput() {
-		totalOutputAmt = totalOutputAmt.Add(totalOutputAmt.Add(totalOutputAmt, spendMsg.Output1.Amount), spendMsg.Fee)
+		totalOutputAmt = new(big.Int).Add(new(big.Int).Add(totalOutputAmt, spendMsg.Output1.Amount), spendMsg.Fee)
 	} else {
-		totalOutputAmt = totalOutputAmt.Add(totalOutputAmt, spendMsg.Fee)
+		totalOutputAmt = new(big.Int).Add(totalOutputAmt, spendMsg.Fee)
 	}
 
 	if totalInputAmt.Cmp(totalOutputAmt) != 0 {

--- a/store/utxoStore.go
+++ b/store/utxoStore.go
@@ -164,9 +164,9 @@ func (store UTXOStore) StoreUTXO(ctx sdk.Context, utxo UTXO) {
 func (store UTXOStore) SpendUTXO(ctx sdk.Context, addr common.Address, pos plasma.Position, spenderKeys [][]byte) sdk.Result {
 	utxo, ok := store.GetUTXO(ctx, addr, pos)
 	if !ok {
-		return sdk.ErrUnknownRequest("output does not exist").Result()
+		return sdk.ErrUnknownRequest(fmt.Sprintf("output with address 0x%x and position %v does not exist", addr, pos)).Result()
 	} else if utxo.Spent {
-		return sdk.ErrUnauthorized("output already spent").Result()
+		return sdk.ErrUnauthorized(fmt.Sprintf("output with address 0x%x and position %v is already spent", addr, pos)).Result()
 	}
 
 	utxo.Spent = true


### PR DESCRIPTION
Cleans up sign and spend commands. Sign now iterates through all utxos for an account and asks to finalize any non finalized transactions. Spend will generate a transaction for the user unless the user specifies the inputs. Moved info back to query command. Will update query in a separate pr

How sign looks now:
```
plasmacli sign acc2

UTXO
Position: (6.0.0.0)
Owner: 0x5475b99e01ac3bb08b24fd754e2868dbb829bc3a
Value: 1000
> Would you like to finalize this transaction? [Y/n]
Y
Enter passphrase:
Confirmation Signature for output with position: (6.0.0.0)
0x8f62af2c70be5c38e08fc022a431e83f6987a27cd434bec590519b29bf243e0b50f98e73c481d8f915849f09b94700468e4ccd75c3e2e34dddc63a66c5719a6000
```

How spend looks now::
```
plasmacli spend 0x5475b99e01ac3bb08b24fd754e2868dbb829bc3a 1000 acc2 --position "(5.0.0.0)"
Enter passphrase:
Committed at block 226334. Hash 0x33363935324545424533373644384435394433334230443145354143453031463045394442354643393935443031324142344136303342393532433146363530
```

Note I only included position in the above example because I haven't fixed generating txs without exiting inputs yet