### PR TITLE
Fix Include-Deposit Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Updated client
 - Updated documentation
 - Upgrade to v0.32.0 of Cosmos SDK, v0.28.0 of TM
+### Fixed
+- [\#147](https://github.com/FourthState/plasma-mvp-sidechain/pull/147) Fix Syncing bug where syncing nodes would panic after processing exitted inputs/deposits. Bug is explained in detail here: [\#143](https://github.com/FourthState/plasma-mvp-sidechain/issues/143)
+- [\#154](https://github.com/FourthState/plasma-mvp-sidechain/pull/154) Fixes issue where include-Deposit msg.Owner == deposit.Owner not enforced. This is necessary to prevent malicious users from rewriting an already included UTXO in store.
 ### Deprecated 
 - Dep is no longer be supported
 

--- a/handlers/anteHandler.go
+++ b/handlers/anteHandler.go
@@ -159,7 +159,7 @@ func includeDepositAnteHandler(ctx sdk.Context, utxoStore store.UTXOStore, plasm
 	if utxoStore.HasUTXO(ctx, msg.Owner, depositPosition) {
 		return ctx, msgs.ErrInvalidTransaction(DefaultCodespace, "deposit, %s, already exists in store", msg.DepositNonce.String()).Result(), true
 	}
-	_, threshold, ok := client.GetDeposit(plasmaStore.CurrentPlasmaBlockNum(ctx), msg.DepositNonce)
+	deposit, threshold, ok := client.GetDeposit(plasmaStore.CurrentPlasmaBlockNum(ctx), msg.DepositNonce)
 	if !ok && threshold == nil {
 		return ctx, msgs.ErrInvalidTransaction(DefaultCodespace, "deposit, %s, does not exist.", msg.DepositNonce.String()).Result(), true
 	}
@@ -169,6 +169,9 @@ func includeDepositAnteHandler(ctx sdk.Context, utxoStore store.UTXOStore, plasm
 	exited := client.HasTxBeenExited(plasmaStore.CurrentPlasmaBlockNum(ctx), depositPosition)
 	if exited {
 		return ctx, msgs.ErrInvalidTransaction(DefaultCodespace, "deposit, %s, has already exitted from rootchain", msg.DepositNonce.String()).Result(), true
+	}
+	if !bytes.Equal(msg.Owner.Bytes(), deposit.Owner.Bytes()) {
+		return ctx, msgs.ErrInvalidTransaction(DefaultCodespace, fmt.Sprintf("msg has the wrong owner field for given deposit. Resubmit with correct deposit owner: %s", deposit.Owner.String())).Result(), true
 	}
 	return ctx, sdk.Result{}, false
 }

--- a/handlers/anteHandler_test.go
+++ b/handlers/anteHandler_test.go
@@ -19,6 +19,7 @@ var (
 	addr       = crypto.PubkeyToAddress(privKey.PublicKey)
 	// bad keys to check against the deposit
 	badPrivKey, _ = crypto.GenerateKey()
+	badAddr       = crypto.PubkeyToAddress(badPrivKey.PublicKey)
 )
 
 type inputUTXO struct {

--- a/handlers/anteHandler_test.go
+++ b/handlers/anteHandler_test.go
@@ -481,6 +481,24 @@ func TestAnteDepositDNE(t *testing.T) {
 
 }
 
+func TestAnteDepositWrongOwner(t *testing.T) {
+	// setup
+	ctx, utxoStore, plasmaStore := setup()
+	// connection always returns valid deposits
+	handler := NewAnteHandler(utxoStore, plasmaStore, conn{})
+
+	// Try to include with wrong owner
+	msg := msgs.IncludeDepositMsg{
+		DepositNonce: big.NewInt(3),
+		Owner:        badAddr,
+	}
+
+	_, res, abort := handler(ctx, msg, false)
+
+	require.False(t, res.IsOK(), "Wrong Owner deposit inclusion did not error")
+	require.True(t, abort, "Wrong owner deposit inclusion did not abort")
+}
+
 func setupInputs(ctx sdk.Context, utxoStore store.UTXOStore, inputs ...inputUTXO) {
 	for _, i := range inputs {
 		utxo := store.UTXO{


### PR DESCRIPTION
Fixes include-deposit bug found by @colin-axner 

Even though deposit handler uses deposit.Owner to construct UTXO, we must still check that msg.Owner == deposit.Owner in AnteHandler

we are using the msg.Owner field to make sure that a deposit is not already in the store
before, an attacker can reverse a spend of a msg by simply reincluding it with the wrong owner
the deposit handler will overwrite the old value