### PR TITLE
Hamdi/config

### DIFF
--- a/app/options.go
+++ b/app/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmad/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"os"
 	"strconv"
 	"time"
 )
@@ -15,8 +16,11 @@ func SetPlasmaOptionsFromConfig(conf config.PlasmaConfig) func(*PlasmaMVPChain) 
 	var privateKey *ecdsa.PrivateKey
 	var blockFinality uint64
 
+	fmt.Println(conf)
+	os.Exit(1)
+
 	if conf.IsOperator {
-		d, err := hex.DecodeString(conf.EthOperatorPrivateKey)
+		d, err := hex.DecodeString(conf.OperatorPrivateKey)
 
 		if err != nil {
 			errMsg := fmt.Sprintf("Could not parse private key: %v", err)

--- a/app/options.go
+++ b/app/options.go
@@ -7,7 +7,6 @@ import (
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmad/config"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"os"
 	"strconv"
 	"time"
 )
@@ -15,9 +14,6 @@ import (
 func SetPlasmaOptionsFromConfig(conf config.PlasmaConfig) func(*PlasmaMVPChain) {
 	var privateKey *ecdsa.PrivateKey
 	var blockFinality uint64
-
-	fmt.Println(conf)
-	os.Exit(1)
 
 	if conf.IsOperator {
 		d, err := hex.DecodeString(conf.OperatorPrivateKey)

--- a/cmd/plasmacli/config/cobra.go
+++ b/cmd/plasmacli/config/cobra.go
@@ -7,10 +7,10 @@ import (
 )
 
 func AddPersistentTMFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().String(client.FlagNode, "tcp://localhost:26657", "<host>:<port> to tendermint rpc interface for this chain")
+	cmd.PersistentFlags().String(client.FlagNode, "", "<host>:<port> to tendermint rpc interface for this chain")
 	cmd.PersistentFlags().Bool(client.FlagTrustNode, false, "Trust connected full node (don't verify proofs for responses)")
 	cmd.PersistentFlags().String(client.FlagChainID, "", "id of the chain. Required if --trust-node=false")
+	viper.BindPFlag(client.FlagNode, cmd.PersistentFlags().Lookup(client.FlagNode))
 	viper.BindPFlag(client.FlagTrustNode, cmd.PersistentFlags().Lookup(client.FlagTrustNode))
 	viper.BindPFlag(client.FlagChainID, cmd.PersistentFlags().Lookup(client.FlagChainID))
-	viper.BindPFlag(client.FlagNode, cmd.PersistentFlags().Lookup(client.FlagNode))
 }

--- a/cmd/plasmacli/config/config.go
+++ b/cmd/plasmacli/config/config.go
@@ -3,66 +3,118 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/viper"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 )
 
 const defaultConfigTemplate = `# This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 
-##### ethereum config options #####
+##### ethereum configuration #####
+
 # Ethereum plasma contract address
-ethereum_plasma_contract_address = "{{ .EthPlasmaContractAddr }}"
+ethereum_contract_address = "{{ .EthPlasmaContractAddr }}"
 
 # Node URL for eth client
 ethereum_nodeurl = "{{ .EthNodeURL }}"
 
-# Number of Ethereum blocks until a transaction is considered final
-ethereum_finality = "{{ .EthBlockFinality }}"`
+
+##### plasamd configuration #####
+
+# Node URL for plasmad
+node = "{{ .PlasmadNodeURL }}"
+
+# Trust the connected plasmad node (don't verify proofs for responses)
+trust_node = {{ .PlasmadTrustNode }}
+
+# Chain identifier. Must be set if trust-node == false
+chain_id = "{{ .PlasmadChainID }}"`
 
 // Must match the above defaultConfigTemplate
-type PlasmaConfig struct {
-	EthPlasmaContractAddr string `mapstructure:"ethereum_plasma_contract_address"`
+type Config struct {
+	// Ethereum config
+	EthPlasmaContractAddr string `mapstructure:"ethereum_contract_address"`
 	EthNodeURL            string `mapstructure:"ethereum_nodeurl"`
-	EthBlockFinality      string `mapstructure:"ethereum_finality"`
+
+	// Plasmad config
+	PlasmadNodeURL   string `mapstructure:"node"`
+	PlasmadTrustNode bool   `mapstructure:"trust_node"`
+	PlasmadChainID   string `mapstructure:"chain_id"`
 }
 
 var configTemplate *template.Template
 
 func init() {
 	var err error
-	tmpl := template.New("plasmaConfigFileTemplate")
+	tmpl := template.New("configFileTemplate")
 	if configTemplate, err = tmpl.Parse(defaultConfigTemplate); err != nil {
 		panic(err)
 	}
+
+	// ensure that none of the cosmos-cli flags have changed
+	var changed bool
+	if client.FlagNode != "node" {
+		changed = true
+	} else if client.FlagTrustNode != "trust-node" {
+		changed = true
+	} else if client.FlagChainID != "chain-id" {
+		changed = true
+	}
+
+	if changed {
+		panic("cosmos client flags have changed. adjust the config file")
+	}
+
 }
 
-func DefaultPlasmaConfig() PlasmaConfig {
-	return PlasmaConfig{"", "http://localhost:8545", "0"}
+func DefaultConfig() Config {
+	return Config{
+		EthPlasmaContractAddr: "",
+		EthNodeURL:            "http://localhost:8545",
+		PlasmadNodeURL:        "tcp://localhost:26657",
+		PlasmadTrustNode:      false,
+		PlasmadChainID:        "",
+	}
+}
+
+// RegisterViper will match client flags with config and register env
+func RegisterViperAndEnv() {
+	viper.SetEnvPrefix("PCLI")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+
+	viper.RegisterAlias("trust_node", "trust-node")
+	viper.RegisterAlias("chain_id", "chain-id")
 }
 
 // parses the plasma.toml file and unmarshals it into a Config struct
-func ParsePlasmaConfigFromViper() (PlasmaConfig, error) {
-	config := DefaultPlasmaConfig()
+func ParseConfigFromViper() (Config, error) {
+	config := Config{}
 	err := viper.Unmarshal(&config)
 	return config, err
 }
 
 // WriteConfigFile renders config using the template and writes it to configFilePath.
-func WritePlasmaConfigFile(configFilePath string, config PlasmaConfig) {
+func WriteConfigFile(configFilePath string, config Config) error {
 	var buffer bytes.Buffer
 
 	if err := configTemplate.Execute(&buffer, &config); err != nil {
-		panic(err)
+		return fmt.Errorf("template: %s", err)
 	}
 
 	if err := cmn.EnsureDir(filepath.Dir(configFilePath), os.ModePerm); err != nil {
-		fmt.Printf("ERROR: failed to create directory: %s, recieved error: { %s }", filepath.Dir(configFilePath), err)
+		return fmt.Errorf("failed to create directory: %s. error: %s", filepath.Dir(configFilePath), err)
 	}
 
 	// 0666 allows for read and write for any user
-	cmn.MustWriteFile(configFilePath, buffer.Bytes(), 0666)
+	if err := cmn.WriteFile(configFilePath, buffer.Bytes(), 0666); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/plasmacli/config/config.go
+++ b/cmd/plasmacli/config/config.go
@@ -88,6 +88,9 @@ func RegisterViperAndEnv() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()
 
+	// The configuration files use underscores while the Cosmos SDK uses
+	// hypens. These aliases align `Viper.Get(..)` for both
+	// the SDK and the configuration file
 	viper.RegisterAlias("trust_node", "trust-node")
 	viper.RegisterAlias("chain_id", "chain-id")
 }
@@ -108,12 +111,12 @@ func WriteConfigFile(configFilePath string, config Config) error {
 	}
 
 	if err := cmn.EnsureDir(filepath.Dir(configFilePath), os.ModePerm); err != nil {
-		return fmt.Errorf("failed to create directory: %s. error: %s", filepath.Dir(configFilePath), err)
+		return fmt.Errorf("ensuredir: %s", err)
 	}
 
 	// 0666 allows for read and write for any user
 	if err := cmn.WriteFile(configFilePath, buffer.Bytes(), 0666); err != nil {
-		return err
+		return fmt.Errorf("writefile: %s", err)
 	}
 
 	return nil

--- a/cmd/plasmacli/config/config.go
+++ b/cmd/plasmacli/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/viper"
 	cmn "github.com/tendermint/tendermint/libs/common"
 	"os"

--- a/cmd/plasmacli/config/config.go
+++ b/cmd/plasmacli/config/config.go
@@ -55,21 +55,6 @@ func init() {
 	if configTemplate, err = tmpl.Parse(defaultConfigTemplate); err != nil {
 		panic(err)
 	}
-
-	// ensure that none of the cosmos-cli flags have changed
-	var changed bool
-	if client.FlagNode != "node" {
-		changed = true
-	} else if client.FlagTrustNode != "trust-node" {
-		changed = true
-	} else if client.FlagChainID != "chain-id" {
-		changed = true
-	}
-
-	if changed {
-		panic("cosmos client flags have changed. adjust the config file")
-	}
-
 }
 
 func DefaultConfig() Config {

--- a/cmd/plasmacli/config/connection.go
+++ b/cmd/plasmacli/config/connection.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"fmt"
+	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/flags"
 	"github.com/FourthState/plasma-mvp-sidechain/eth"
 	ethcmn "github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/viper"
-	tmcli "github.com/tendermint/tendermint/libs/cli"
 )
 
 var plasmaContract *eth.Plasma
@@ -30,8 +30,11 @@ func setupContractConn() (*eth.Plasma, error) {
 		return nil, err
 	}
 
-	// Check to see if the eth connection params have changed
-	dir := viper.GetString(tmcli.HomeFlag)
+	dir := viper.GetString(flags.Home)
+	if dir[len(dir)-1] != '/' {
+		dir = dir + "/"
+	}
+
 	if conf.EthNodeURL == "" {
 		return nil, fmt.Errorf("please specify a node url for eth connection in %sconfig.toml", dir)
 	} else if conf.EthPlasmaContractAddr == "" || !ethcmn.IsHexAddress(conf.EthPlasmaContractAddr) {

--- a/cmd/plasmacli/flags/flags.go
+++ b/cmd/plasmacli/flags/flags.go
@@ -1,0 +1,9 @@
+package flags
+
+import (
+	tmcli "github.com/tendermint/tendermint/libs/cli"
+)
+
+const (
+	Home = tmcli.HomeFlag
+)

--- a/cmd/plasmacli/main.go
+++ b/cmd/plasmacli/main.go
@@ -3,12 +3,7 @@ package main
 import (
 	"fmt"
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/subcmd"
-	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"os"
-)
-
-const (
-	FlagHome = tmcli.HomeFlag
 )
 
 func main() {

--- a/cmd/plasmacli/main.go
+++ b/cmd/plasmacli/main.go
@@ -3,7 +3,12 @@ package main
 import (
 	"fmt"
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/subcmd"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"os"
+)
+
+const (
+	FlagHome = tmcli.HomeFlag
 )
 
 func main() {

--- a/cmd/plasmacli/store/keystore_test.go
+++ b/cmd/plasmacli/store/keystore_test.go
@@ -15,15 +15,13 @@ import (
 func TestAccounts(t *testing.T) {
 	// setup testing env
 	os.Mkdir("testing", os.ModePerm)
-	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+	InitKeystore("./testing")
 
 	// cleanup
 	defer func() {
 		viper.Reset()
 		os.RemoveAll("testing")
 	}()
-
-	InitKeystore()
 
 	cases := []string{
 		"mykey",

--- a/cmd/plasmacli/store/sigs_test.go
+++ b/cmd/plasmacli/store/sigs_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/flags"
 	"github.com/FourthState/plasma-mvp-sidechain/plasma"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/spf13/viper"
@@ -13,7 +14,7 @@ import (
 func TestSavSig(t *testing.T) {
 	// setup testing env
 	os.Mkdir("testing", os.ModePerm)
-	os.Setenv("PCLI_HOME", "./testing")
+	viper.Set(flags.Home, "./testing")
 
 	// cleanup
 	defer func() {
@@ -66,7 +67,7 @@ func TestSavSig(t *testing.T) {
 func TestBadSigs(t *testing.T) {
 	// setup testing env
 	os.Mkdir("testing", os.ModePerm)
-	os.Setenv("PCLI_HOME", "./testing")
+	viper.Set(flags.Home, "./testing")
 
 	// cleanup
 	defer func() {
@@ -89,7 +90,7 @@ func TestBadSigs(t *testing.T) {
 func TestMultiConfirmSig(t *testing.T) {
 	// setup testing env
 	os.Mkdir("testing", os.ModePerm)
-	os.Setenv("PCLI_HOME", "./testing")
+	viper.Set(flags.Home, "./testing")
 
 	// cleanup
 	defer func() {

--- a/cmd/plasmacli/store/sigs_test.go
+++ b/cmd/plasmacli/store/sigs_test.go
@@ -13,7 +13,7 @@ import (
 func TestSavSig(t *testing.T) {
 	// setup testing env
 	os.Mkdir("testing", os.ModePerm)
-	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+	os.Setenv("PCLI_HOME", "./testing")
 
 	// cleanup
 	defer func() {
@@ -66,7 +66,7 @@ func TestSavSig(t *testing.T) {
 func TestBadSigs(t *testing.T) {
 	// setup testing env
 	os.Mkdir("testing", os.ModePerm)
-	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+	os.Setenv("PCLI_HOME", "./testing")
 
 	// cleanup
 	defer func() {
@@ -89,7 +89,7 @@ func TestBadSigs(t *testing.T) {
 func TestMultiConfirmSig(t *testing.T) {
 	// setup testing env
 	os.Mkdir("testing", os.ModePerm)
-	viper.Set(DirFlag, os.ExpandEnv("./testing"))
+	os.Setenv("PCLI_HOME", "./testing")
 
 	// cleanup
 	defer func() {

--- a/cmd/plasmacli/subcmd/eth/query/root.go
+++ b/cmd/plasmacli/subcmd/eth/query/root.go
@@ -33,7 +33,7 @@ func QueryCmd() *cobra.Command {
 var queryCmd = &cobra.Command{
 	Use:   "query",
 	Short: "Query for rootchain related information",
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		plasma, err := config.GetContractConn()
 		plasmaContract = plasma
 		return err

--- a/cmd/plasmacli/subcmd/eth/root.go
+++ b/cmd/plasmacli/subcmd/eth/root.go
@@ -51,7 +51,7 @@ var ethCmd = &cobra.Command{
 	Short: "Interact with the plasma smart contract",
 	Long: `Configurations for interacting with the rootchain contract can be specified in <dirpath>/plasma.toml.
 An eth node instance needs to be running for this command to work.`,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
 		plasma, err := config.GetContractConn()
 		plasmaContract = plasma
 		return err

--- a/cmd/plasmacli/subcmd/keys/root.go
+++ b/cmd/plasmacli/subcmd/keys/root.go
@@ -1,7 +1,6 @@
 package keys
 
 import (
-	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/store"
 	"github.com/spf13/cobra"
 )
 
@@ -11,15 +10,7 @@ const (
 	fileF = "file"
 )
 
-var keysCmd = &cobra.Command{
-	Use:   "keys",
-	Short: "Manage local private keys",
-	Long:  `Keys allows you to manage your local keystore.`,
-}
-
 func KeysCmd() *cobra.Command {
-	store.InitKeystore()
-
 	keysCmd.AddCommand(
 		AddCmd(),
 		DeleteCmd(),
@@ -29,4 +20,10 @@ func KeysCmd() *cobra.Command {
 	)
 
 	return keysCmd
+}
+
+var keysCmd = &cobra.Command{
+	Use:   "keys",
+	Short: "Manage local private keys",
+	Long:  `Keys allows you to manage your local keystore.`,
 }

--- a/cmd/plasmacli/subcmd/root.go
+++ b/cmd/plasmacli/subcmd/root.go
@@ -3,6 +3,7 @@ package subcmd
 import (
 	"fmt"
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/config"
+	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/flags"
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/store"
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/subcmd/eth"
 	"github.com/FourthState/plasma-mvp-sidechain/cmd/plasmacli/subcmd/keys"
@@ -11,7 +12,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"os"
 	"path/filepath"
 )
@@ -20,12 +20,8 @@ import (
 var homeDir = os.ExpandEnv("$HOME/.plasmacli/")
 
 func RootCmd() *cobra.Command {
-	if tmcli.HomeFlag != "home" {
-		panic("tendermint home flag changed. adjust to the change")
-	}
-
 	cobra.EnableCommandSorting = false
-	rootCmd.PersistentFlags().String(tmcli.HomeFlag, homeDir, "home directory for plasmacli")
+	rootCmd.PersistentFlags().String(flags.Home, homeDir, "home directory for plasmacli")
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -55,7 +51,7 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		config.RegisterViperAndEnv()
-		homeDir := viper.GetString(tmcli.HomeFlag)
+		homeDir := viper.GetString(flags.Home)
 
 		store.InitKeystore(homeDir)
 

--- a/cmd/plasmacli/subcmd/root.go
+++ b/cmd/plasmacli/subcmd/root.go
@@ -11,38 +11,24 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"os"
 	"path/filepath"
 )
 
-// default directory
-var homeDir string = os.ExpandEnv("$HOME/.plasmacli/")
-
-// Flags
-const ()
-
-func init() {
-	// initConfig to be ran when Execute is called
-	cobra.OnInitialize(initConfig)
-}
-
-// initConfig reads in config file and ENV variables if set
-func initConfig() {
-	viper.AutomaticEnv()
-}
+// default home directory
+var homeDir = os.ExpandEnv("$HOME/.plasmacli/")
 
 func RootCmd() *cobra.Command {
+	if tmcli.HomeFlag != "home" {
+		panic("tendermint home flag changed. adjust to the change")
+	}
+
 	cobra.EnableCommandSorting = false
-	rootCmd.PersistentFlags().StringP(store.DirFlag, "d", homeDir, "directory for plasmacli")
+	rootCmd.PersistentFlags().StringVar(&homeDir, tmcli.HomeFlag, homeDir, "home directory for plasmacli")
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-	}
-
-	viper.AddConfigPath(homeDir)
-	plasmaDir := filepath.Join(homeDir, "plasma.toml")
-	if _, err := os.Stat(plasmaDir); os.IsNotExist(err) {
-		config.WritePlasmaConfigFile(plasmaDir, config.DefaultPlasmaConfig())
 	}
 
 	rootCmd.AddCommand(
@@ -67,4 +53,27 @@ var rootCmd = &cobra.Command{
 	Use:           "plasmacli",
 	Short:         "Plasma Client",
 	SilenceErrors: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		config.RegisterViperAndEnv()
+		homeDir := viper.GetString(tmcli.HomeFlag)
+
+		store.InitKeystore(homeDir)
+
+		configFilepath := filepath.Join(homeDir, "config.toml")
+		if _, err := os.Stat(configFilepath); os.IsNotExist(err) {
+			if err := config.WriteConfigFile(configFilepath, config.DefaultConfig()); err != nil {
+				return err
+			}
+		} else if err != nil {
+			return err
+		}
+
+		viper.AddConfigPath(homeDir)
+		viper.SetConfigName("config")
+		if err := viper.MergeInConfig(); err != nil {
+			return err
+		}
+
+		return nil
+	},
 }

--- a/cmd/plasmacli/subcmd/root.go
+++ b/cmd/plasmacli/subcmd/root.go
@@ -25,7 +25,7 @@ func RootCmd() *cobra.Command {
 	}
 
 	cobra.EnableCommandSorting = false
-	rootCmd.PersistentFlags().StringVar(&homeDir, tmcli.HomeFlag, homeDir, "home directory for plasmacli")
+	rootCmd.PersistentFlags().String(tmcli.HomeFlag, homeDir, "home directory for plasmacli")
 	if err := viper.BindPFlags(rootCmd.PersistentFlags()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/plasmacli/subcmd/tx/root.go
+++ b/cmd/plasmacli/subcmd/tx/root.go
@@ -25,6 +25,7 @@ func TxCmd() *cobra.Command {
 		SpendCmd(),
 		SignCmd(),
 	)
+
 	return txCmd
 }
 

--- a/cmd/plasmad/config/config.go
+++ b/cmd/plasmad/config/config.go
@@ -10,34 +10,38 @@ import (
 const defaultConfigTemplate = `# This is a TOML config file.
 # For more information, see https://github.com/toml-lang/toml
 
-##### ethereum config options #####
-# Boolean specifying if this node is the operator of the plasma contract
-is_operator = "{{ .IsOperator }}"
-
-# Hex encoded private key
-# Used to sign eth transactions interacting with the contract
-ethereum_operator_privatekey = "{{ .EthOperatorPrivateKey }}"
+##### ethereum configuration #####
 
 # Ethereum plasma contract address
 ethereum_plasma_contract_address = "{{ .EthPlasmaContractAddr }}"
-
-# Plasma block commitment rate. i.e 1m30s, 1m, 1h, etc.
-plasma_block_commitment_rate = "{{ .PlasmaCommitmentRate }}"
 
 # Node URL for eth client
 ethereum_nodeurl = "{{ .EthNodeURL }}"
 
 # Number of Ethereum blocks until a submitted block header is considered final
-ethereum_finality = "{{ .EthBlockFinality }}"`
+ethereum_finality = "{{ .EthBlockFinality }}"
+
+##### plasma configuration #####
+
+# Plasma block commitment rate. i.e 1m30s, 1m, 1h, etc.
+block_commitment_rate = "{{ .PlasmaCommitmentRate }}"
+
+# Boolean specifying if this node is the operator of the plasma contract
+is_operator = "{{ .IsOperator }}"
+
+# Hex encoded private key
+# Used to sign eth transactions interacting with the contract
+operator_privatekey = "{{ .OperatorPrivateKey }}"`
 
 // Must match the above defaultConfigTemplate
 type PlasmaConfig struct {
-	IsOperator            bool   `mapstructure:"is_operator"`
-	EthOperatorPrivateKey string `mapstructure:"ethereum_operator_privatekey"`
 	EthPlasmaContractAddr string `mapstructure:"ethereum_plasma_contract_address"`
-	PlasmaCommitmentRate  string `mapstructure:"plasma_block_commitment_rate"`
 	EthNodeURL            string `mapstructure:"ethereum_nodeurl"`
 	EthBlockFinality      string `mapstructure:"ethereum_finality"`
+
+	IsOperator           bool   `mapstructure:"is_operator"`
+	OperatorPrivateKey   string `mapstructure:"operator_privatekey"`
+	PlasmaCommitmentRate string `mapstructure:"block_commitment_rate"`
 }
 
 var configTemplate *template.Template
@@ -51,7 +55,15 @@ func init() {
 }
 
 func DefaultPlasmaConfig() PlasmaConfig {
-	return PlasmaConfig{false, "", "", "30s", "http://localhost:8545", "16"}
+	return PlasmaConfig{
+		EthPlasmaContractAddr: "",
+		EthNodeURL:            "http://localhost:8545",
+		EthBlockFinality:      "16",
+
+		IsOperator:           false,
+		OperatorPrivateKey:   "",
+		PlasmaCommitmentRate: "1m",
+	}
 }
 
 // TestPlasmaConfig writes the plasma.toml file used for testing
@@ -59,12 +71,13 @@ func DefaultPlasmaConfig() PlasmaConfig {
 // Contract address and private key generated deterministically using the "plasma" moniker with ganache
 func TestPlasmaConfig() PlasmaConfig {
 	return PlasmaConfig{
-		IsOperator:            true,
-		EthOperatorPrivateKey: "9cd69f009ac86203e54ec50e3686de95ff6126d3b30a19f926a0fe9323c17181",
 		EthPlasmaContractAddr: "31E491FC70cDb231774c61B7F46d94699dacE664",
-		PlasmaCommitmentRate:  "1m",
 		EthNodeURL:            "http://localhost:8545",
 		EthBlockFinality:      "0",
+
+		IsOperator:           true,
+		OperatorPrivateKey:   "9cd69f009ac86203e54ec50e3686de95ff6126d3b30a19f926a0fe9323c17181",
+		PlasmaCommitmentRate: "1m",
 	}
 }
 


### PR DESCRIPTION
Streamline the configuration options. 

Configuration respects viper's precedence order:
```
Viper uses the following precedence order. Each item takes precedence over the item below it:

    explicit call to Set
    flag
    env
    config
    key/value store
    default
```

1. Plasma.toml -> config.toml. The configuration includes ethereum and plasmad configuration options

2. Configuration can be set using the environment variables prefixed with `PCLI` or `PD`. (plasmacli/plasmad)
- i.e `export PCLI_TRUST_NODE=true`

3. Introduce a new persistent flag to change plasmacli's home directory. Changed from `directory` to `home` to conform to tendermint's configuration. The Verifier, when `trust-node=false`, expects a home directory. 
- The home flag is defined within `plasmacli/flags` to reduce the number of `tendermint/libs/cli` imports. The sdk defines the home flag in later versions. The flags package can be removed in the next update